### PR TITLE
Get FishNet running

### DIFF
--- a/bin/protogen
+++ b/bin/protogen
@@ -40,8 +40,8 @@ def main(args=None):
 
     # Generate Track and Trade protos
     protoc(
-        JOIN(TOP_DIR, "/protos"),
-        "/processor",
+        JOIN(TOP_DIR, "protos"),
+        "processor",
         "supply_chain_processor/protobuf")
 
 

--- a/bin/supply_chain_tp
+++ b/bin/supply_chain_tp
@@ -25,10 +25,7 @@ build_str = "lib.{}-{}.{}".format(
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-    'sdk', 'python'))
-sys.path.insert(0, os.path.join(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-    'families', 'track_and_trade', 'processor'))
+    'processor'))
 
 from supply_chain_processor.main import main
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fish_net",
   "version": "0.0.0",
-  "description": "A Track and Trade client web app for trading fish",
+  "description": "A Sawtooth Supply Chain client web app for trading fish",
   "main": "",
   "scripts": {
     "compile_protos": "node scripts/compile_protos.js > src/protos.json",

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -20,7 +20,7 @@ const m = require('mithril')
 const _ = require('lodash')
 const sjcl = require('sjcl')
 
-const STORAGE_KEY = 'tnt.authorization'
+const STORAGE_KEY = 'fish_net.authorization'
 let authToken = null
 
 /**

--- a/client/src/services/parsing.js
+++ b/client/src/services/parsing.js
@@ -17,7 +17,7 @@
 'use strict'
 
 const _ = require('lodash')
-const moment = require('moment')
+const moment = require('moment').default
 const { FLOAT_PRECISION } = require('./payloads')
 
 const STRINGIFIERS = {

--- a/client/src/services/payloads.js
+++ b/client/src/services/payloads.js
@@ -48,7 +48,7 @@ const actionMap = ACTIONS.reduce((map, enumName) => {
 
 // Compile Protobufs
 const root = protobuf.Root.fromJSON(protoJson)
-const TTPayload = root.lookup('TTPayload')
+const SCPayload = root.lookup('SCPayload')
 const PropertyValue = root.lookup('PropertyValue')
 const PropertySchema = root.lookup('PropertySchema')
 const Location = root.lookup('Location')
@@ -75,7 +75,7 @@ actionMap.createRecordType.xform = schemaXform
 actionMap.updateProperties.xform = valueXform
 
 /**
- * Encodes a new TTPayload with the specified action
+ * Encodes a new SCPayload with the specified action
  */
 const encode = (actionKey, actionData) => {
   const action = actionMap[actionKey]
@@ -83,8 +83,8 @@ const encode = (actionKey, actionData) => {
     throw new Error('There is no payload action with that key')
   }
 
-  return TTPayload.encode({
-    action: TTPayload.Action[action.enum],
+  return SCPayload.encode({
+    action: SCPayload.Action[action.enum],
     timestamp: Math.floor(Date.now() / 1000),
     [actionKey]: action.proto.create(action.xform(actionData))
   }).finish()

--- a/client/src/services/transactions.js
+++ b/client/src/services/transactions.js
@@ -23,15 +23,15 @@ const { signer, TransactionEncoder } = require('sawtooth-sdk/client')
 const modals = require('../components/modals')
 const api = require('../services/api')
 
-const STORAGE_KEY = 'tnt.encryptedKey'
+const STORAGE_KEY = 'fish_net.encryptedKey'
 
 let txnEncoder = null
 const encoderSettings = {
-  familyName: 'track_and_trade',
+  familyName: 'supply_chain',
   familyVersion: '1.0',
   payloadEncoding: 'application/protobuf',
-  inputs: ['1c1108'],
-  outputs: ['1c1108'],
+  inputs: ['3400de'],
+  outputs: ['3400de'],
   batcherPubkey: null
 }
 

--- a/client/src/views/dashboard.js
+++ b/client/src/views/dashboard.js
@@ -27,10 +27,10 @@ const Dashboard = {
         m('h5',
           m('em',
             'Powered by ',
-            m('strong', 'Sawtooth: Track and Trade')))),
+            m('strong', 'Sawtooth Supply Chain')))),
       m('.blurb',
         m('p',
-          m('em', 'Track and Trade'),
+          m('em', 'Sawtooth Supply Chain'),
           ' is a general purpose supply chain solution built using the ',
           'power of ',
           m('a[href="https://github.com/hyperledger/sawtooth-core"]',
@@ -57,7 +57,7 @@ const Dashboard = {
           'ownership or possession of the fish entirely. For the ',
           'adventurous, these actions can also be accomplished directly ',
           'with the REST API running on the ',
-          m('em', 'Track and Trade'),
+          m('em', 'Supply Chain'),
           ' server, perfect for automated IoT sensors.'))
     ]
   }

--- a/client/src/views/fish_detail.js
+++ b/client/src/views/fish_detail.js
@@ -17,7 +17,7 @@
 'use strict'
 
 const m = require('mithril')
-const moment = require('moment')
+const moment = require('moment').default
 const truncate = require('lodash/truncate')
 
 const {MultiSelect} = require('../components/forms')

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,73 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    image: hyperledger/sawtooth-tp_settings:latest
+    container_name: sawtooth-settings-tp-default
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    entrypoint: settings-tp -vv tcp://validator:4004
+
+  validator:
+    image: hyperledger/sawtooth-validator:latest
+    container_name: sawtooth-validator-default
+    expose:
+      - 4004
+    ports:
+      - "4004:4004"
+    # start the validator with an empty genesis batch
+    entrypoint: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth keygen my_key && \
+        sawtooth config genesis -k /root/.sawtooth/keys/my_key.priv && \
+        sawtooth admin genesis config-genesis.batch && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://eth0:8800 \
+        \""
+
+  rest-api:
+    image: hyperledger/sawtooth-rest_api:latest
+    container_name: sawtooth-rest-api-default
+    expose:
+      - 4004
+      - 8008
+    ports:
+      - "8008:8008"
+    depends_on:
+      - validator
+    entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8008 -vv
+
+  client:
+    image: hyperledger/sawtooth-all:latest
+    volumes:
+      - ./:/sawtooth-supply-chain
+    container_name: sawtooth-client-default
+    expose:
+      - 8008
+      - 4004
+    depends_on:
+      - rest-api
+    entrypoint: "bash -c \"\
+        sawtooth keygen && \
+        tail -f /dev/null \
+        \""

--- a/docs/source/family_specification.rst
+++ b/docs/source/family_specification.rst
@@ -1,11 +1,11 @@
-************************************************
-Track and Trade Transaction Family Specification
-************************************************
+******************************************************
+Sawtooth Supply Chain Transaction Family Specification
+******************************************************
 
 Overview
 ========
 
-The Track and Trade (T&T) transaction family allows users to track
+The Sawtooth Supply Chain transaction family allows users to track
 goods as they move through a supply chain. Records for goods include a
 history of ownership and custodianship, as well as histories for a
 variety of properties such as temperature and location. These
@@ -16,19 +16,19 @@ types.
 State
 =====
 
-All T&T objects are serialized using Protocol Buffers before being
+All Supply Chain objects are serialized using Protocol Buffers before being
 stored in state. These objects include: Agents, Properties
 (accompanied by their auxiliary PropertyPage objects), Proposals,
 Records, and RecordTypes. As described in the Addressing_ section
 below, these objects are stored in separate sub-namespaces under the
-T&T namespace. To handle hash collisions, all objects are stored in
+Supply Chain namespace. To handle hash collisions, all objects are stored in
 lists within protobuf "Container" objects.
 
 
 Records
 -------
 
-Records represent the goods being tracked by Track and Trade. Almost
+Records represent the goods being tracked by Supply Chain. Almost
 every transaction references some Record.
 
 A Record contains a unique identifier, the name of a RecordType, and
@@ -392,19 +392,19 @@ then by ``timestamp`` (earliest to latest).
 Addressing
 ----------
 
-T&T objects are stored under the namespace obtained by taking the
+Supply Chain objects are stored under the namespace obtained by taking the
 first six characters of the SHA-512 hash of the string
-``track_and_trade``:
+``supply_chain``:
 
 .. code-block:: pycon
 
    >>> def get_hash(string):
    ...     return hashlib.sha512(string.encode('utf-8')).hexdigest()
    ...
-   >>> get_hash('track_and_trade')[:6]
-   '1c1108'
+   >>> get_hash('supply_chain')[:6]
+   '3400de'
 
-After its namespace prefix, the next two characters of a T&T object's
+After its namespace prefix, the next two characters of a Supply Chain object's
 address are a string based on the object's type:
 
 - Agent: ``ae``
@@ -450,8 +450,8 @@ PropertyPage is:
 
 .. code-block:: pycon
 
-    >>> get_hash('track_and_trade')[:6] + 'ea'  + get_hash('fish-456')[:36] + get_hash('temperature')[:22] + hex(28)[2:].zfill(4)
-    '1c1108ea840d00edc7507ed05cfb86938e3624ada6c7f08bfeb8fd09b963f81f9d001c'
+    >>> get_hash('supply_chain')[:6] + 'ea'  + get_hash('fish-456')[:36] + get_hash('temperature')[:22] + hex(28)[2:].zfill(4)
+    '3400deea840d00edc7507ed05cfb86938e3624ada6c7f08bfeb8fd09b963f81f9d001c'
 
 
 Transactions
@@ -460,12 +460,12 @@ Transactions
 Transaction Payload
 -------------------
 
-All T&T transactions are wrapped in a tagged payload object to allow
+All Supply Chain transactions are wrapped in a tagged payload object to allow
 for the transaction to be dispatched to appropriate handling logic.
 
 .. code-block:: protobuf
 
-   message TTPayload {
+   message SCPayload {
        enum Action {
            CREATE_AGENT = 1;
            CREATE_RECORD = 2;

--- a/processor/supply_chain_processor/addressing.py
+++ b/processor/supply_chain_processor/addressing.py
@@ -25,7 +25,7 @@ def _hash(string):
 # characters depend on the type of object being stored. There is no
 # formula for deriving these infixes.
 
-FAMILY_NAME = 'track_and_trade'
+FAMILY_NAME = 'supply_chain'
 
 NAMESPACE = _hash(FAMILY_NAME)[:6]
 

--- a/processor/supply_chain_processor/handler.py
+++ b/processor/supply_chain_processor/handler.py
@@ -39,7 +39,7 @@ from supply_chain_processor.protobuf.record_pb2 import RecordContainer
 from supply_chain_processor.protobuf.record_pb2 import RecordType
 from supply_chain_processor.protobuf.record_pb2 import RecordTypeContainer
 
-from supply_chain_processor.protobuf.payload_pb2 import TTPayload
+from supply_chain_processor.protobuf.payload_pb2 import SCPayload
 from supply_chain_processor.protobuf.payload_pb2 import AnswerProposalAction
 
 import supply_chain_processor.addressing as addressing
@@ -53,7 +53,7 @@ PROPERTY_PAGE_MAX_LENGTH = 256
 TOTAL_PROPERTY_PAGE_MAX = 16 ** 4 - 1
 
 
-class TTTransactionHandler:
+class SCTransactionHandler:
     @property
     def family_name(self):
         return addressing.FAMILY_NAME
@@ -72,7 +72,7 @@ class TTTransactionHandler:
 
     def apply(self, transaction, state):
         '''
-        A TTPayload consists of a timestamp, an action tag, and
+        A SCPayload consists of a timestamp, an action tag, and
         attributes corresponding to various actions (create_agent,
         create_record, etc). The appropriate attribute will be
         selected depending on the action tag, and that information
@@ -81,7 +81,7 @@ class TTTransactionHandler:
         handler function (_create_agent, _create_record, etc).
         _unpack_transaction gets the signing key, the timestamp, and
         the action tag out of the transaction, then returns the
-        signing key, the timestamp, and the appropriate TTPayload
+        signing key, the timestamp, and the appropriate SCPayload
         attribute and handler function.
 
         Besides this, the transaction's timestamp is verified, since
@@ -877,8 +877,8 @@ def _verify_timestamp(timestamp):
 
 
 def _unpack_transaction(transaction):
-    '''Return the transaction signing key, the TTPayload timestamp, the
-    appropriate TTPayload action attribute, and the appropriate
+    '''Return the transaction signing key, the SCPayload timestamp, the
+    appropriate SCPayload action attribute, and the appropriate
     handler function (with the latter two determined by the constant
     TYPE_TO_ACTION_HANDLER table.
     '''
@@ -887,7 +887,7 @@ def _unpack_transaction(transaction):
 
     signer = header.signer_pubkey
 
-    payload = TTPayload()
+    payload = SCPayload()
     payload.ParseFromString(transaction.payload)
 
     action = payload.action
@@ -904,13 +904,13 @@ def _unpack_transaction(transaction):
 
 
 TYPE_TO_ACTION_HANDLER = {
-    TTPayload.CREATE_AGENT: ('create_agent', _create_agent),
-    TTPayload.CREATE_RECORD: ('create_record', _create_record),
-    TTPayload.FINALIZE_RECORD: ('finalize_record', _finalize_record),
-    TTPayload.CREATE_RECORD_TYPE: ('create_record_type',
+    SCPayload.CREATE_AGENT: ('create_agent', _create_agent),
+    SCPayload.CREATE_RECORD: ('create_record', _create_record),
+    SCPayload.FINALIZE_RECORD: ('finalize_record', _finalize_record),
+    SCPayload.CREATE_RECORD_TYPE: ('create_record_type',
                                    _create_record_type),
-    TTPayload.UPDATE_PROPERTIES: ('update_properties', _update_properties),
-    TTPayload.CREATE_PROPOSAL: ('create_proposal', _create_proposal),
-    TTPayload.ANSWER_PROPOSAL: ('answer_proposal', _answer_proposal),
-    TTPayload.REVOKE_REPORTER: ('revoke_reporter', _revoke_reporter),
+    SCPayload.UPDATE_PROPERTIES: ('update_properties', _update_properties),
+    SCPayload.CREATE_PROPOSAL: ('create_proposal', _create_proposal),
+    SCPayload.ANSWER_PROPOSAL: ('answer_proposal', _answer_proposal),
+    SCPayload.REVOKE_REPORTER: ('revoke_reporter', _revoke_reporter),
 }

--- a/processor/supply_chain_processor/main.py
+++ b/processor/supply_chain_processor/main.py
@@ -22,10 +22,10 @@ import pkg_resources
 from colorlog import ColoredFormatter
 
 from sawtooth_sdk.processor.core import TransactionProcessor
-from supply_chain_processor.handler import TTTransactionHandler
+from supply_chain_processor.handler import SCTransactionHandler
 
 
-DISTRIBUTION_NAME = 'sawtooth-track-and-trade'
+DISTRIBUTION_NAME = 'sawtooth-supply-chain'
 
 
 def create_console_handler(verbose_level):
@@ -108,7 +108,7 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None,
 
     processor = TransactionProcessor(url=args.endpoint)
 
-    handler = TTTransactionHandler()
+    handler = SCTransactionHandler()
 
     processor.add_handler(handler)
 

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -19,7 +19,7 @@ import "property.proto";
 import "proposal.proto";
 
 
-message TTPayload {
+message SCPayload {
   enum Action {
     CREATE_AGENT = 0;
     CREATE_RECORD = 1;

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -28,7 +28,7 @@ if (SECRET === undefined) {
   console.warn('WARNING! No secret provided at startup!')
   console.warn('JWT authorization tokens will be insecure.')
   console.warn('Set the "SECRET" environment variable to create secure tokens.')
-  SECRET = 'tnt-secret'
+  SECRET = 'supply-chain-secret'
 }
 
 // Hashes a password as promised

--- a/server/blockchain/index.js
+++ b/server/blockchain/index.js
@@ -22,7 +22,7 @@ const { Message } = require('sawtooth-sdk/protobuf')
 const deltas = require('./deltas')
 const batcher = require('./batcher')
 
-const PREFIX = '1c1108'
+const PREFIX = '3400de'
 const VALIDATOR_URL = process.env.VALIDATOR_URL || 'tcp://localhost:4004'
 const stream = new Stream(VALIDATOR_URL)
 

--- a/server/blockchain/protos.js
+++ b/server/blockchain/protos.js
@@ -58,7 +58,7 @@ const compile = () => {
       'RecordTypeContainer'
     ]),
     loadProtos('payload.proto', [
-      'TTPayload',
+      'SCPayload',
       'CreateAgentAction',
       'FinalizeRecordAction',
       'CreateRecordAction',

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -22,7 +22,7 @@ const jsSchema = require('js-schema')
 
 const HOST = process.env.DB_HOST || 'localhost'
 const PORT = process.env.DB_PORT || 28015
-const NAME = process.env.DB_NAME || 'tnt'
+const NAME = process.env.DB_NAME || 'supply_chain'
 
 // Connection to db for query methods, run connect before querying
 let connection = null

--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,7 @@ Promise.all([
     app.use('/api', api)
 
     app.listen(PORT, () => {
-      console.log(`Track and Trade Server listening on port ${PORT}`)
+      console.log(`Supply Chain Server listening on port ${PORT}`)
     })
   })
   .catch(err => console.error(err.message))

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tnt_server",
+  "name": "supply_chain_server",
   "version": "0.0.0",
-  "description": "A database and API for the Track and Trade client app",
+  "description": "A database and API for clients using Sawtooth Supply Chain",
   "main": "index.js",
   "directories": {
     "test": "tests"

--- a/server/scripts/bootstrap_database.js
+++ b/server/scripts/bootstrap_database.js
@@ -20,7 +20,7 @@ const r = require('rethinkdb')
 
 const HOST = process.env.DB_HOST || 'localhost'
 const PORT = process.env.DB_PORT || 28015
-const NAME = process.env.DB_NAME || 'tnt'
+const NAME = process.env.DB_NAME || 'supply_chain'
 
 r.connect({host: HOST, port: PORT})
   .then(conn => {

--- a/server/scripts/create_fish_type_batch.js
+++ b/server/scripts/create_fish_type_batch.js
@@ -25,11 +25,11 @@ const protos = require('../blockchain/protos')
 
 const privateKey = signer.makePrivateKey()
 const encoder = new TransactionEncoder(privateKey, {
-  familyName: 'track_and_trade',
+  familyName: 'supply_chain',
   familyVersion: '1.0',
   payloadEncoding: 'application/protobuf',
-  inputs: ['1c1108'],
-  outputs: ['1c1108']
+  inputs: ['3400de'],
+  outputs: ['3400de']
 })
 const batcher = new BatchEncoder(privateKey)
 
@@ -70,16 +70,16 @@ protos.compile()
       }]
     }
 
-    const agentPayload = protos.TTPayload.encode({
-      action: protos.TTPayload.Action.CREATE_AGENT,
+    const agentPayload = protos.SCPayload.encode({
+      action: protos.SCPayload.Action.CREATE_AGENT,
       timestamp: Math.floor(Date.now() / 1000),
       createAgent: protos.CreateAgentAction.create({
         name: 'FishNet Admin'
       })
     }).finish()
 
-    const typePayload = protos.TTPayload.encode({
-      action: protos.TTPayload.Action.CREATE_RECORD_TYPE,
+    const typePayload = protos.SCPayload.encode({
+      action: protos.SCPayload.Action.CREATE_RECORD_TYPE,
       timestamp: Math.floor(Date.now() / 1000),
       createRecordType: protos.CreateRecordTypeAction.create({
         name: fishType.name,

--- a/server/scripts/seed_example_data.js
+++ b/server/scripts/seed_example_data.js
@@ -32,32 +32,32 @@ const { records, agents } = require(`./${DATA}`)
 let batcherPubkey = null
 
 const createPayload = message => {
-  return protos.TTPayload.encode(_.assign({
+  return protos.SCPayload.encode(_.assign({
     timestamp: Math.floor(Date.now() / 1000)
   }, message)).finish()
 }
 
 const createTxn = (privateKey, payload) => {
   return new TransactionEncoder(privateKey, {
-    familyName: 'track_and_trade',
+    familyName: 'supply_chain',
     familyVersion: '1.0',
     payloadEncoding: 'application/protobuf',
-    inputs: ['1c1108'],
-    outputs: ['1c1108'],
+    inputs: ['3400de'],
+    outputs: ['3400de'],
     batcherPubkey
   }).create(payload)
 }
 
 const createProposal = (privateKey, action) => {
   return createTxn(privateKey, createPayload({
-    action: protos.TTPayload.Action.CREATE_PROPOSAL,
+    action: protos.SCPayload.Action.CREATE_PROPOSAL,
     createProposal: protos.CreateProposalAction.create(action)
   }))
 }
 
 const answerProposal = (privateKey, action) => {
   return createTxn(privateKey, createPayload({
-    action: protos.TTPayload.Action.ANSWER_PROPOSAL,
+    action: protos.SCPayload.Action.ANSWER_PROPOSAL,
     answerProposal: protos.AnswerProposalAction.create(action)
   }))
 }
@@ -85,7 +85,7 @@ protos.compile()
     console.log('Creating Agents . . .')
     const agentAdditions = agents.map(agent => {
       return createTxn(agent.privateKey, createPayload({
-        action: protos.TTPayload.Action.CREATE_AGENT,
+        action: protos.SCPayload.Action.CREATE_AGENT,
         createAgent: protos.CreateAgentAction.create({ name: agent.name })
       }))
     })
@@ -122,7 +122,7 @@ protos.compile()
       })
 
       return createTxn(agents[record.ownerIndex || 0].privateKey, createPayload({
-        action: protos.TTPayload.Action.CREATE_RECORD,
+        action: protos.SCPayload.Action.CREATE_RECORD,
         createRecord: protos.CreateRecordAction.create({
           recordId: record.recordId,
           recordType: record.recordType,

--- a/server/scripts/update_example_data.js
+++ b/server/scripts/update_example_data.js
@@ -40,25 +40,25 @@ const VARIANCE_FACTOR = 0.75
 let batcherPubkey = null
 
 const createPayload = message => {
-  return protos.TTPayload.encode(_.assign({
+  return protos.SCPayload.encode(_.assign({
     timestamp: Math.floor(Date.now() / 1000)
   }, message)).finish()
 }
 
 const createTxn = (privateKey, payload) => {
   return new TransactionEncoder(privateKey, {
-    familyName: 'track_and_trade',
+    familyName: 'supply_chain',
     familyVersion: '1.0',
     payloadEncoding: 'application/protobuf',
-    inputs: ['1c1108'],
-    outputs: ['1c1108'],
+    inputs: ['3400de'],
+    outputs: ['3400de'],
     batcherPubkey
   }).create(payload)
 }
 
 const createUpdate = (privateKey, recordId, property) => {
   return createTxn(privateKey, createPayload({
-    action: protos.TTPayload.Action.UPDATE_PROPERTIES,
+    action: protos.SCPayload.Action.UPDATE_PROPERTIES,
     updateProperties: protos.UpdatePropertiesAction.create({
       recordId,
       properties: [protos.PropertyValue.create(property)]

--- a/tests/sawtooth_sc_test/supply_chain_message_factory.py
+++ b/tests/sawtooth_sc_test/supply_chain_message_factory.py
@@ -18,7 +18,7 @@ import time
 
 from sawtooth_processor_test.message_factory import MessageFactory
 
-from supply_chain_processor.protobuf.payload_pb2 import TTPayload
+from supply_chain_processor.protobuf.payload_pb2 import SCPayload
 from supply_chain_processor.protobuf.payload_pb2 import CreateAgentAction
 from supply_chain_processor.protobuf.payload_pb2 import CreateProposalAction
 from supply_chain_processor.protobuf.payload_pb2 import AnswerProposalAction
@@ -40,7 +40,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
 
-class TrackAndTradeMessageFactory:
+class SupplyChainMessageFactory:
     def __init__(self, private=None, public=None):
         self._factory = MessageFactory(
             encoding='application/protobuf',
@@ -55,8 +55,8 @@ class TrackAndTradeMessageFactory:
         self.signer_address = addressing.make_agent_address(self.public_key)
 
     def create_agent(self, name):
-        payload = _make_tt_payload(
-            action=TTPayload.CREATE_AGENT,
+        payload = _make_sc_payload(
+            action=SCPayload.CREATE_AGENT,
             create_agent=CreateAgentAction(name=name))
 
         return self._create_transaction(
@@ -66,8 +66,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def create_record_type(self, name, *properties):
-        payload = _make_tt_payload(
-            action=TTPayload.CREATE_RECORD_TYPE,
+        payload = _make_sc_payload(
+            action=SCPayload.CREATE_RECORD_TYPE,
             create_record_type=CreateRecordTypeAction(
                 name=name,
                 properties=[
@@ -89,8 +89,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def create_record(self, record_id, record_type, properties_dict):
-        payload = _make_tt_payload(
-            action=TTPayload.CREATE_RECORD,
+        payload = _make_sc_payload(
+            action=SCPayload.CREATE_RECORD,
             create_record=CreateRecordAction(
                 record_id=record_id,
                 record_type=record_type,
@@ -123,8 +123,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def finalize_record(self, record_id):
-        payload = _make_tt_payload(
-            action=TTPayload.FINALIZE_RECORD,
+        payload = _make_sc_payload(
+            action=SCPayload.FINALIZE_RECORD,
             finalize_record=FinalizeRecordAction(
                 record_id=record_id))
 
@@ -137,8 +137,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def update_properties(self, record_id, properties_dict):
-        payload = _make_tt_payload(
-            action=TTPayload.UPDATE_PROPERTIES,
+        payload = _make_sc_payload(
+            action=SCPayload.UPDATE_PROPERTIES,
             update_properties=UpdatePropertiesAction(
                 record_id=record_id,
                 properties=[
@@ -168,8 +168,8 @@ class TrackAndTradeMessageFactory:
         if properties is None:
             properties = []
 
-        payload = _make_tt_payload(
-            action=TTPayload.CREATE_PROPOSAL,
+        payload = _make_sc_payload(
+            action=SCPayload.CREATE_PROPOSAL,
             create_proposal=CreateProposalAction(
                 record_id=record_id,
                 receiving_agent=receiving_agent,
@@ -196,8 +196,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def answer_proposal(self, record_id, receiving_agent, role, response):
-        payload = _make_tt_payload(
-            action=TTPayload.ANSWER_PROPOSAL,
+        payload = _make_sc_payload(
+            action=SCPayload.ANSWER_PROPOSAL,
             answer_proposal=AnswerProposalAction(
                 record_id=record_id,
                 receiving_agent=receiving_agent,
@@ -229,8 +229,8 @@ class TrackAndTradeMessageFactory:
         )
 
     def revoke_reporter(self, record_id, reporter_id, properties):
-        payload = _make_tt_payload(
-            action=TTPayload.REVOKE_REPORTER,
+        payload = _make_sc_payload(
+            action=SCPayload.REVOKE_REPORTER,
             revoke_reporter=RevokeReporterAction(
                 record_id=record_id,
                 reporter_id=reporter_id,
@@ -264,7 +264,7 @@ class TrackAndTradeMessageFactory:
         address = addressing.make_agent_address(public_key)
 
         return self._create_transaction(
-            payload=TTPayload().SerializeToString(),
+            payload=SCPayload().SerializeToString(),
             inputs=[address],
             outputs=[address]
         )
@@ -277,8 +277,8 @@ class TrackAndTradeMessageFactory:
         return self._factory.create_batch([transaction])
 
 
-def _make_tt_payload(**kwargs):
-    return TTPayload(
+def _make_sc_payload(**kwargs):
+    return SCPayload(
         timestamp=round(time.time()),
         **kwargs
     ).SerializeToString()


### PR DESCRIPTION
With the changes in this PR, you should be able to run FishNet. This does not update `run_tests`, `run_docker_tests`, `run_lint`, or `run_bandit`. The deployment process will also be streamlined in future PRs.

To run, download the repo, and from the project directory:
```bash
docker-compose up
```

Then in a new process:
```bash
./bin/protogen
docker exec -it sawtooth-client-default bash
```

This will enter the sawtooth client container which has the `sawtooth_sdk` in the PYTHONPATH, which the transaction processor needs. So from within that container:
```bash
cd sawtooth-supply-chain/
./bin/transaction-processor
```

Open one more process:
```bash
cd client/
npm install
npm run build
cd ../server/
npm install
npm run init
npm run make-fish
curl localhost:8008/batches -X POST -H "Content-Type: application/octet-stream" --data-binary @fish.batch 
npm start
```

Now you should be able to navigate to `http://localhost:3000/fish` and see the FishNet client. Creating users, fish, and updating data should all work.