### PR TITLE
Add basic filter parameters to list queries

### DIFF
--- a/asset_client/src/views/list_assets.js
+++ b/asset_client/src/views/list_assets.js
@@ -33,7 +33,7 @@ const AssetList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/records').then((records) => {
+      api.get('/records?recordType=asset').then((records) => {
         vnode.state.records = records
         vnode.state.records.sort((a, b) => {
           return getLatestPropertyUpdateTime(b) - getLatestPropertyUpdateTime(a)

--- a/fish_client/src/views/list_fish.js
+++ b/fish_client/src/views/list_fish.js
@@ -33,7 +33,7 @@ const FishList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/records').then((records) => {
+      api.get('/records?recordType=fish').then((records) => {
         vnode.state.records = records
         vnode.state.records.sort((a, b) => {
           return getLatestPropertyUpdateTime(b) - getLatestPropertyUpdateTime(a)

--- a/server/api/agents.js
+++ b/server/api/agents.js
@@ -16,9 +16,12 @@
  */
 'use strict'
 
+const _ = require('lodash')
 const db = require('../db/agents')
 
-const list = db.list
+const FILTER_KEYS = ['name', 'publicKey']
+
+const list = params => db.list(_.pick(params, FILTER_KEYS))
 
 const fetch = ({ publicKey, authedKey }) => db.fetch(publicKey, publicKey === authedKey)
 

--- a/server/api/records.js
+++ b/server/api/records.js
@@ -16,7 +16,10 @@
  */
 'use strict'
 
+const _ = require('lodash')
 const db = require('../db/records')
+
+const FILTER_KEYS = ['recordId', 'recordType']
 
 const fetchProperty = ({recordId, propertyName}) => {
   return db.fetchProperty(recordId, propertyName)
@@ -26,8 +29,8 @@ const fetchRecord = ({recordId, authedKey}) => {
   return db.fetchRecord(recordId, authedKey)
 }
 
-const listRecords = authedKey => {
-  return db.listRecords(authedKey)
+const listRecords = params => {
+  return db.listRecords(params.authedKey, _.pick(params, FILTER_KEYS))
 }
 
 module.exports = {

--- a/server/db/agents.js
+++ b/server/db/agents.js
@@ -68,8 +68,9 @@ const isReporter = agent => property => {
 const getTable = (tableName, block) =>
       r.table(tableName).filter(hasCurrentBlock(block))
 
-const listQuery = block => {
+const listQuery = filterQuery => block => {
   return getTable('agents', block)
+    .filter(filterQuery)
     .map(agent => r.expr({
       'name': getName(agent),
       'key': getPublicKey(agent),
@@ -110,7 +111,7 @@ const fetchUser = publicKey => {
     .nth(0)
 }
 
-const list = () => db.queryWithCurrentBlock(listQuery)
+const list = filterQuery => db.queryWithCurrentBlock(listQuery(filterQuery))
 
 const fetch = (publicKey, auth) =>
       db.queryWithCurrentBlock(fetchQuery(publicKey, auth))

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -228,8 +228,9 @@ const fetchRecordQuery = (recordId, authedKey) => block => {
   return findRecord(recordId)(block).do(_loadRecord(block, authedKey))
 }
 
-const listRecordsQuery = authedKey => block => {
+const listRecordsQuery = (authedKey, filterQuery) => block => {
   return getTable('records', block)
+    .filter(filterQuery)
     .map(_loadRecord(block, authedKey))
     .coerceTo('array')
 }
@@ -244,8 +245,8 @@ const fetchRecord = (recordId, authedKey) => {
   return db.queryWithCurrentBlock(fetchRecordQuery(recordId, authedKey))
 }
 
-const listRecords = authedKey => {
-  return db.queryWithCurrentBlock(listRecordsQuery(authedKey))
+const listRecords = (authedKey, filterQuery) => {
+  return db.queryWithCurrentBlock(listRecordsQuery(authedKey, filterQuery))
 }
 
 module.exports = {

--- a/server/system/config.js
+++ b/server/system/config.js
@@ -86,7 +86,7 @@ config.set = (key, value) => {
   const configPath = path.resolve(__dirname, '../config.json')
   const jsonConfig = JSON.stringify(diskConfig, null, 2)
   fs.writeFile(configPath, jsonConfig, 'utf8', err => {
-    if (err) throw err
+    if (err) console.error(err)
   })
 }
 


### PR DESCRIPTION
API now accepts some simple filter parameters to the `/records` and
`/agents` routes. This is used by the fish and asset clients to only
display fish and assets respectively.