### PR TITLE
Add comprehensive shell container

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,32 @@ please see its
 [sawtooth-core repo](https://github.com/hyperledger/sawtooth-core) or its
 [published docs](https://sawtooth.hyperledger.org/docs/).
 
-Running alongside the core Sawtooth components, Supply Chain includes a number
-of custom components:
+## Contents
+
+- [Components](#components)
+- [Usage](#usage)
+  - [Start Up](#start-up)
+  - [Running Scripts in the Shell](#running-scripts-in-the-shell)
+  - [Configuring API Keys and Secrets](#configuring-api-keys-and-secrets)
+- [Development](#development)
+  - [Restarting Components](#restarting-components)
+  - [Manually Building Generated Files](#manually-building-generated-files)
+- [Documentation](#documentation)
+- [License](#license)
+
+## Components
+
+Running alongside the core components from Hyperledger Sawtooth, Supply Chain
+includes a number of elements customizing the blockchain and user interaction
+with it:
 
 - a **transaction processor** which handles Supply Chain transaction logic
 - a **server** which provides an HTTP/JSON API, syncs blockchain state to a
-  local db, and serves example clients
+  local database, and serves example clients
 - the **AssetTrack** example client for tracking generic assets
 - the **FishNet** example client for tracking fish from catch to table
-- a **shell** with the dependencies to run any commands and scripts
+- a **shell** container with the dependencies to run any commands and scripts
+
 
 ## Usage
 
@@ -29,8 +46,10 @@ specific to your OS to install and run whatever components are required to run
 `docker` and `docker-compose` from your command line. This is only dependency
 required to run Supply Chain components.
 
-Now, with Docker installed and this repo cloned, from the root project
-directory, simply run:
+### Start Up
+
+Once Docker is installed and you've cloned this repo, navigate to the root
+project directory and run:
 
 ```bash
 docker-compose up
@@ -54,7 +73,7 @@ command:
 docker-compose down
 ```
 
-### Using the Shell
+### Running Scripts in the Shell
 
 Running `docker-compose up`, will automatically run all scripts necessary to
 use all Supply Chain components. However if you want to run any additional
@@ -113,6 +132,8 @@ a template to follow.
 
 ## Development
 
+### Restarting Components
+
 The default Docker containers use the `volumes` command to link directly to the
 source code on your host machine. As a result any changes you make will
 immediately be reflected in Supply Chain components without having to rebuild
@@ -134,7 +155,7 @@ The available container names include:
 - supply-settings-tp
 - supply-rest-api
 
-### Generating Protobuf and Client Files
+### Manually Building Generated Files
 
 Files in the `protos/` directory are used to generate classes for other
 components. This is done automatically on `up`, but if you make changes to

--- a/README.md
+++ b/README.md
@@ -54,35 +54,27 @@ command:
 docker-compose down
 ```
 
-### Using the Shell to Setup Web App Data
+### Using the Shell
 
-The example web apps require that their respective "RecordTypes" be sent to the
-blockchain before they will run properly. This can be done from within the
-Supply Chain Shell docker container. Open a new terminal and run:
+Running `docker-compose up`, will automatically run all scripts necessary to
+use all Supply Chain components. However if you want to run any additional
+scripts, such as scripts to automatically update sample blockchain data, a shell
+container is provided with all necessary dependencies installed. To enter the
+shell, simply open a terminal window and run:
 
 ```bash
 docker exec -it supply-shell bash
 ```
 
-Once inside the shell container you can navigate to the server directory and
-run the necessary scripts:
+Once inside the shell, you might try running the one of the update scripts to
+see live updates populate in an example web app. First navigate to the server
+directory:
 
 ```bash
 cd server/
-npm run make-asset
-npm run make-fish
 ```
 
-After the RecordTypes are created, from the same directory you can also run
-scripts to seed some sample data:
-
-```bash
-npm run seed-sample-assets
-npm run seed-sample-fish
-```
-
-If you have seeded the apps with sample data, you can also run scripts to send
-updates over time:
+Then run one of the two provided npm scripts:
 
 ```bash
 npm run update-sample-assets
@@ -97,7 +89,7 @@ certain number are submitted (default 25):
 RATE=3 LIMIT=10 npm run update-sample-assets
 ```
 
-If you just want to  exit the shell, you can simply run:
+If you just want to exit the shell, you can simply run:
 
 ```bash
 exit

--- a/README.md
+++ b/README.md
@@ -1,79 +1,194 @@
 
-![Hyperledger Sawtooth](images/sawtooth_logo_light_blue-small.png)  
+![Hyperledger Sawtooth](images/sawtooth_logo_light_blue-small.png)
 
-Sawtooth Supply Chain
------------------
+# Sawtooth Supply Chain
 
-This is a distributed application to help you trace the provenance and other contextual information of any asset.
- It can be used as-is or customized for different usages.
-This supply chain dApp runs on top of Hyperledger Sawtooth, an enterprise blockchain. 
-To learn more about Hyperledger Sawtooth please see its [sawtooth-core repo](https://github.com/hyperledger/sawtooth-core)
- or its [published docs](https://sawtooth.hyperledger.org/docs/).
+This is a distributed application to help you trace the provenance and other
+contextual information of any asset. It can be used as-is or customized for
+different use cases. This distributed application runs on top of Hyperledger
+Sawtooth, an enterprise blockchain. To learn more about Hyperledger Sawtooth
+please see its
+[sawtooth-core repo](https://github.com/hyperledger/sawtooth-core) or its
+[published docs](https://sawtooth.hyperledger.org/docs/).
 
-The scripts below will help you run the entire blockchain locally using containers. 
+Running alongside the core Sawtooth components, Supply Chain includes a number
+of custom components:
 
-Getting Started with Sawtooth Supply Chain
------------------
+- a **transaction processor** which handles Supply Chain transaction logic
+- a **server** which provides an HTTP/JSON API, syncs blockchain state to a
+  local db, and serves example clients
+- the **AssetTrack** example client for tracking generic assets
+- the **FishNet** example client for tracking fish from catch to table
+- a **shell** with the dependencies to run any commands and scripts
 
-These instructions will enable you to launch a supply chain focused blockchain with web interface, and seed it with some sample assets.
+## Usage
 
-Requirements:
+This project utilizes [Docker](https://www.docker.com/what-docker) to simplify
+dependencies and deployment. After cloning this repo, follow the instructions
+specific to your OS to install and run whatever components are required to run
+`docker` and `docker-compose` from your command line. This is only dependency
+required to run Supply Chain components.
 
-Git - https://git-scm.com/download/mac
+Now, with Docker installed and this repo cloned, from the root project
+directory, simply run:
 
-Docker - https://www.docker.com/docker-mac 
+```bash
+docker-compose up
+```
 
-NPM - https://nodejs.org/en/download/ 
+This will take awhile the first time it runs, but when complete will be running
+all required components in separate containers. Many of the components will be
+available through HTTP endpoints, including:
 
-Python3 - https://www.python.org/downloads/mac-osx/ 
+- The Supply Chain REST API will be at **http://localhost:8020/api**
+- AssetTrack will be at **http://localhost:8020/asset**
+- FishNet will be at **http://localhost:8020/fish**
+- RethinkDB's admin panel will be available at **http://localhost:8021**
+- Sawtooth's blockchain REST API will be available at **http://localhost:8022**
 
-GRPC - $ python3 -m pip install grpcio 
+In bash you can shutdown these components with the key combination: `ctrl-C`.
+You can shutdown _and_ remove the containers (destroying their data), with the
+command:
 
-GRPC Tools - $ python3 -m pip install grpcio-tools
+```bash
+docker-compose down
+```
 
+### Using the Shell to Setup Web App Data
 
-Setup Instructions:
+The example web apps require that their respective "RecordTypes" be sent to the
+blockchain before they will run properly. This can be done from within the
+Supply Chain Shell docker container. Open a new terminal and run:
 
-1. $ git clone https://github.com/hyperledger/sawtooth-supply-chain.git
-2. Navigate to sawtooth-supply-chain directory 
-3. $ ./bin/protogen
-4. $ docker-compose up
-5. Open a new terminal
-6. Navigate to sawtooth-supply-chain/server
-7. $ npm install
-8. $ npm run make-asset
-9. $ npm run seed-sample-assets
-10. Navigate your browser to localhost:3000/asset
+```bash
+docker exec -it supply-shell bash
+```
 
-Optionally run data feeds to update the assets (watch maps and graphs update in the browser):
-11. $ npm run update-sample-assets
+Once inside the shell container you can navigate to the server directory and
+run the necessary scripts:
 
-Shutdown Instructions:
-1. Navigate to sawtooth-supply-chain directory 
-2. $ docker-compose down
+```bash
+cd server/
+npm run make-asset
+npm run make-fish
+```
 
-Subsequent Runs:
-1. $ docker-compose up
-2. Open a new terminal
-3. Navigate to sawtooth-supply-chain/server
-4. $ npm run make-asset
-5. $ npm run seed-sample-assets
-6. Navigate your browser to localhost:3000/asset
-7. $ npm run update-sample-assets
+After the RecordTypes are created, from the same directory you can also run
+scripts to seed some sample data:
 
-Documentation
--------------
+```bash
+npm run seed-sample-assets
+npm run seed-sample-fish
+```
 
-The latest documentation for Sawtooth Supply Chain is available within this repo in
-the [docs](docs) subdirectory.
+If you have seeded the apps with sample data, you can also run scripts to send
+updates over time:
 
-License
--------
+```bash
+npm run update-sample-assets
+npm run update-sample-fish
+```
 
-Hyperledger Sawtooth software is licensed under the [Apache License Version 2.0](LICENSE) software license.
+You can customize how many updates are submitted per minute with the `RATE`
+environment variable (default 6), and use `LIMIT` to stop the updates after a
+certain number are submitted (default 25):
 
-Hyperledger Sawtooth Supply Chain documentation in the [docs](docs) subdirectory is licensed under
-a Creative Commons Attribution 4.0 International License.  You may obtain a copy of the
-license at: http://creativecommons.org/licenses/by/4.0/.
+```bash
+RATE=3 LIMIT=10 npm run update-sample-assets
+```
+
+If you just want to  exit the shell, you can simply run:
+
+```bash
+exit
+```
+
+### Configuring API Keys and Secrets
+
+While the Server runs out of the box with sensible defaults, there are a number
+of secrets and API keys which will not be secure unless set explicitly. While
+this is fine for demo purposes, any actual deployment set the following
+properties:
+
+- **JWT_SECRET**: can be any random string
+- **PRIVATE_KEY**: must be 64 random hexadecimal characters
+- **MAPS_API_KEY**: provided by [Google Maps](https://developers.google.com/maps/documentation/javascript/get-api-key)
+
+These properties can be set one of two ways, through an environment variable,
+or (preferably) by creating a file named `config.json` file in the `server/`
+directory. A file named `config.json.example` is provided which should provide
+a template to follow.
+
+## Development
+
+The default Docker containers use the `volumes` command to link directly to the
+source code on your host machine. As a result any changes you make will
+immediately be reflected in Supply Chain components without having to rebuild
+them. However, typically you _will_ have to restart a component before it can
+take advantage of any changes. Rather than restarting every container, you can
+restart a single component from separate terminal using the container name. For
+example:
+
+```bash
+docker restart supply-server
+```
+
+The available container names include:
+- supply-shell
+- supply-processor
+- supply-server
+- supply-rethink
+- supply-validator
+- supply-settings-tp
+- supply-rest-api
+
+### Generating Protobuf and Client Files
+
+Files in the `protos/` directory are used to generate classes for other
+components. This is done automatically on `up`, but if you make changes to
+these files and wish to rebuild the generated files immediately, you can do so
+from within the Supply Chain Shell:
+
+```bash
+docker exec -it supply-shell bash
+```
+
+Once in the shell, you can generate the necessary Python classes simply by
+running:
+
+```bash
+protogen
+```
+
+For the example clients, in addition to rebuilding them on Protobuf changes,
+any changes to their source code will require their static files be rebuilt.
+Fortunately the server does _not_ need to be restart in order to reflect
+these changes, just rebuild the static files and refresh your browser (the
+browser cache may have to be emptied):
+
+```bash
+cd asset_client/
+npm run build
+```
+
+```bash
+cd fish_client/
+npm run build
+```
+
+## Documentation
+
+The latest documentation for Sawtooth Supply Chain is available within this
+repo in the [docs](docs) subdirectory.
+
+## License
+
+Hyperledger Sawtooth software is licensed under the
+[Apache License Version 2.0](LICENSE) software license.
+
+Hyperledger Sawtooth Supply Chain documentation in the [docs](docs)
+subdirectory is licensed under a Creative Commons Attribution 4.0 International
+License.  You may obtain a copy of the license at:
+http://creativecommons.org/licenses/by/4.0/.
 
 ![Open Source Award Badge](images/rookies16-small.png)

--- a/bin/splice_json
+++ b/bin/splice_json
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+const { resolve } = require('path')
+
+const baseDir = process.cwd()
+const jsonPaths = process.argv.slice(2)
+
+// Deeply combines objects, overwriting primitive data, but recursively
+// checking nested objects for unique keys. For example:
+//   {a: 1, b: {c: 2}} + {a: 3, b: {x: 5}} -> {a: 3, b: {c: 2, x: 5}}
+const spliceObjects = (a, b) => {
+  return Object.keys(b).reduce((spliced, key) => {
+    if (typeof a[key] === 'object' && typeof b[key] === 'object') {
+      spliced[key] = spliceObjects(a[key], b[key])
+    } else {
+      spliced[key] = b[key]
+    }
+    return spliced
+  }, Object.assign({}, a))
+}
+
+// Splice the JSON files specified then sent to stdout as JSON string
+process.stdout.write(JSON.stringify(jsonPaths
+  .map(relPath => resolve(baseDir, relPath))
+  .map(absPath => require(absPath))
+  .reduce((spliced, jsonObj) => spliceObjects(spliced, jsonObj), {})))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,36 @@ version: '2.1'
 
 services:
 
+  shell:
+    image: supply-shell
+    container_name: supply-shell
+    build:
+      context: .
+      dockerfile: shell/Dockerfile
+    volumes:
+      - .:/sawtooth-supply-chain
+      - /sawtooth-supply-chain/asset_client/node_modules
+      - /sawtooth-supply-chain/fish_client/node_modules
+      - /sawtooth-supply-chain/server/node_modules
+    depends_on:
+      - rethink
+      - rest-api
+    environment:
+      - SERVER=http://server:3000
+    command: |
+      bash -c "
+        protogen &&
+        cd asset_client/ && npm run build && cd - &&
+        cd fish_client/ && npm run build && cd - &&
+        if [ ! -f /root/.sawtooth/keys/root.priv ]; then
+          sawtooth keygen &&
+          cd server/ &&
+          DB_HOST=rethink npm run init &&
+          cd -
+        fi;
+        tail -f /dev/null
+      "
+
   processor:
     image: supply-tp
     container_name: supply-tp
@@ -28,6 +58,9 @@ services:
         - no_proxy
     volumes:
       - .:/sawtooth-supply-chain
+    depends_on:
+      - shell
+      - validator
     entrypoint: |
       /sawtooth-supply-chain/bin/supply_chain_tp -vv tcp://validator:4004
 
@@ -51,10 +84,10 @@ services:
     depends_on:
       - validator
       - rethink
+      - shell
     command: |
       bash -c "
-        set -x &&
-        DB_HOST=rethink npm run init &&
+        sleep 15 &&
         VALIDATOR_URL=tcp://validator:4004 DB_HOST=rethink node index.js
       "
 
@@ -110,18 +143,3 @@ services:
       sawtooth-rest-api -vv
         --connect tcp://validator:4004
         --bind rest-api:8008
-
-  shell:
-    image: hyperledger/sawtooth-shell:1.0
-    container_name: supply-shell
-    volumes:
-      - ./:/sawtooth-supply-chain
-    depends_on:
-      - rest-api
-    entrypoint: |
-      bash -c "
-        if [ ! -f /root/.sawtooth/keys/root.priv ]; then
-          sawtooth keygen
-        fi;
-        tail -f /dev/null
-      "

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,8 @@ services:
       - rethink
       - rest-api
     environment:
+      - VALIDATOR_URL=tcp://validator:4004
+      - DB_HOST=rethink
       - SERVER=http://server:3000
     command: |
       bash -c "
@@ -41,7 +43,11 @@ services:
         if [ ! -f /root/.sawtooth/keys/root.priv ]; then
           sawtooth keygen &&
           cd server/ &&
-          DB_HOST=rethink npm run init &&
+          npm run init &&
+          npm run make-asset &&
+          npm run make-fish &&
+          npm run seed-sample-assets &&
+          npm run seed-sample-fish &&
           cd -
         fi;
         tail -f /dev/null

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
     entrypoint: |
       sawtooth-rest-api -vv
         --connect tcp://validator:4004
-        --bind sawtooth-rest-api:8008
+        --bind rest-api:8008
 
   shell:
     image: hyperledger/sawtooth-shell:1.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,11 +85,10 @@ services:
       - validator
       - rethink
       - shell
-    command: |
-      bash -c "
-        sleep 15 &&
-        VALIDATOR_URL=tcp://validator:4004 DB_HOST=rethink node index.js
-      "
+    environment:
+      - VALIDATOR_URL=tcp://validator:4004
+      - DB_HOST=rethink
+    entrypoint: node index.js
 
   rethink:
     image: rethinkdb

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     pkg-config \
     build-essential \
     libzmq3-dev \
- && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_6.x \
+ && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_8.x \
  && chmod 755 /tmp/setup-node.sh \
  && /tmp/setup-node.sh \
  && apt-get install nodejs -y -q \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -37,24 +37,11 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && npm install -g prebuild-install
 
-WORKDIR /sawtooth-supply-chain
-
-# Install Dependencies
-COPY asset_client/package.json asset_client/
-RUN cd asset_client/ && npm install && cd ..
-
-COPY fish_client/package.json fish_client/
-RUN cd fish_client/ && npm install && cd ..
-
-COPY server/package.json server/
-RUN cd server/ && npm install && cd ..
-
-# Build Clients
-COPY . .
-
-RUN cd asset_client/ && npm run build && cd ..
-RUN cd fish_client/ && npm run build && cd ..
-
 WORKDIR /sawtooth-supply-chain/server
 
+COPY server/package.json .
+RUN npm install
+
 EXPOSE 3000/tcp
+
+CMD ["node" "index.js"]

--- a/server/Dockerfile-installed
+++ b/server/Dockerfile-installed
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     pkg-config \
     build-essential \
     libzmq3-dev \
- && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_6.x \
+ && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_8.x \
  && chmod 755 /tmp/setup-node.sh \
  && /tmp/setup-node.sh \
  && apt-get install nodejs -y -q \

--- a/server/Dockerfile-installed
+++ b/server/Dockerfile-installed
@@ -58,3 +58,5 @@ RUN cd fish_client/ && npm run build && cd ..
 WORKDIR /sawtooth-supply-chain/server
 
 EXPOSE 3000/tcp
+
+CMD ["node" "index.js"]

--- a/server/index.js
+++ b/server/index.js
@@ -30,9 +30,8 @@ Promise.all([
   db.connect(),
   protos.compile()
 ])
+  .then(blockchain.subscribe)
   .then(() => {
-    blockchain.subscribe()
-
     config.clients.forEach(client => {
       app.use(client.url, express.static(client.path))
       console.log(`Added client at url "${client.url}"`)

--- a/server/scripts/bootstrap_database.js
+++ b/server/scripts/bootstrap_database.js
@@ -45,12 +45,6 @@ r.connect({host: HOST, port: PORT})
         }).run(conn)
       })
       .then(() => {
-        console.log('Creating "blocks" table...')
-        return r.db(NAME).tableCreate('blocks', {
-          primaryKey: 'blockNum'
-        }).run(conn)
-      })
-      .then(() => {
         console.log('Creating "agents" table...')
         return r.db(NAME).tableCreate('agents').run(conn)
       })
@@ -103,6 +97,12 @@ r.connect({host: HOST, port: PORT})
           r.row('receivingAgent'),
           r.row('role')
         ]).run(conn)
+      })
+      .then(() => {
+        console.log('Creating "blocks" table...')
+        return r.db(NAME).tableCreate('blocks', {
+          primaryKey: 'blockNum'
+        }).run(conn)
       })
       .then(() => {
         console.log('Bootstrapping complete, closing connection.')

--- a/server/scripts/run_sample_updates.js
+++ b/server/scripts/run_sample_updates.js
@@ -20,6 +20,7 @@ const _ = require('lodash')
 const request = require('request-promise-native')
 const protos = require('../blockchain/protos')
 const {
+  awaitServerPubkey,
   getTxnCreator,
   submitTxns,
   encodeTimestampedPayload
@@ -27,7 +28,6 @@ const {
 
 const SERVER = process.env.SERVER || 'http://localhost:3000'
 const DATA = process.env.DATA
-
 if (DATA.indexOf('.json') === -1) {
   throw new Error('Use the "DATA" environment variable to specify a JSON file')
 }
@@ -168,9 +168,8 @@ const makeUpdateSubmitter = (count = 0) => () => {
 
 // Compile protos, fetch batcher pubkey, then begin submitting updates
 protos.compile()
-  .then(() => request(`${SERVER}/api/info`))
-  .then(res => {
-    const batcherPublicKey = JSON.parse(res).pubkey
+  .then(awaitServerPubkey)
+  .then(batcherPublicKey => {
     const txnCreators = {}
 
     createTxn = (privateKey, payload) => {

--- a/server/scripts/seed_core_types.js
+++ b/server/scripts/seed_core_types.js
@@ -16,17 +16,15 @@
  */
 'use strict'
 
-const request = require('request-promise-native')
 const protos = require('../blockchain/protos')
 const {
+  awaitServerPubkey,
   getTxnCreator,
   submitTxns,
   encodeTimestampedPayload
 } = require('../system/submit_utils')
 
-const SERVER = process.env.SERVER || 'http://localhost:3000'
 const DATA = process.env.DATA
-
 if (DATA.indexOf('.json') === -1) {
   throw new Error('Use the "DATA" environment variable to specify a JSON file')
 }
@@ -34,8 +32,7 @@ if (DATA.indexOf('.json') === -1) {
 const types = require(`./${DATA}`)
 
 protos.compile()
-  .then(() => request(`${SERVER}/api/info`))
-  .then(res => JSON.parse(res).pubkey)
+  .then(awaitServerPubkey)
   .then(batcherPublicKey => getTxnCreator(null, batcherPublicKey))
   .then(createTxn => {
     const agentPayload = encodeTimestampedPayload({

--- a/server/scripts/seed_sample_data.js
+++ b/server/scripts/seed_sample_data.js
@@ -20,6 +20,7 @@ const _ = require('lodash')
 const request = require('request-promise-native')
 const protos = require('../blockchain/protos')
 const {
+  awaitServerPubkey,
   getTxnCreator,
   submitTxns,
   encodeTimestampedPayload
@@ -27,7 +28,6 @@ const {
 
 const SERVER = process.env.SERVER || 'http://localhost:3000'
 const DATA = process.env.DATA
-
 if (DATA.indexOf('.json') === -1) {
   throw new Error('Use the "DATA" environment variable to specify a JSON file')
 }
@@ -50,9 +50,8 @@ const answerProposal = (privateKey, action) => {
 }
 
 protos.compile()
-  .then(() => request(`${SERVER}/api/info`))
-  .then(res => {
-    const batcherPublicKey = JSON.parse(res).pubkey
+  .then(awaitServerPubkey)
+  .then(batcherPublicKey => {
     const txnCreators = {}
 
     createTxn = (privateKey, payload) => {

--- a/server/system/config.js
+++ b/server/system/config.js
@@ -67,13 +67,19 @@ if (!config.JWT_SECRET) {
     'Set "JWT_SECRET" as an environment variable or in "config.json" file.')
 }
 
-// Default to just asset client if no static clients are specified
+// Default to both asset and fish clients if none are specified
 if (!config.clients) {
-  config.clients = config.clients || [{
-    url: '/asset',
-    path: '../asset_client/public'
-  }]
-  console.warn('No clients specified, defaulting to AssetTrack.')
+  config.clients = [
+    {
+      url: '/asset',
+      path: '../asset_client/public'
+    },
+    {
+      url: '/fish',
+      path: '../fish_client/public'
+    }
+  ]
+  console.warn('No clients specified, defaulting to AssetTrack and FishNet.')
   console.warn('Specify static clients with the "clients" key in "config.json"')
 }
 

--- a/server/system/config.js
+++ b/server/system/config.js
@@ -42,6 +42,7 @@ initConfigValue('VALIDATOR_URL', 'tcp://localhost:4004')
 initConfigValue('DB_HOST', 'localhost')
 initConfigValue('DB_PORT', 28015)
 initConfigValue('DB_NAME', 'supply_chain')
+initConfigValue('RETRY_WAIT', 5000)
 initConfigValue('SIGNING_ALGORITHM', 'secp256k1')
 
 // Setup config variables with no defaults

--- a/server/system/submit_utils.js
+++ b/server/system/submit_utils.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const _ = require('lodash')
+const request = require('request-promise-native')
+const { createHash } = require('crypto')
+const secp256k1 = require('sawtooth-sdk/signing/secp256k1')
+const {
+  Transaction,
+  TransactionHeader,
+  TransactionList
+} = require('sawtooth-sdk/protobuf')
+const protos = require('../blockchain/protos')
+
+const FAMILY_NAME = 'supply_chain'
+const FAMILY_VERSION = '1.0'
+const NAMESPACE = '3400de'
+
+const SERVER = process.env.SERVER || 'http://localhost:3000'
+
+const encodeHeader = (signerPublicKey, batcherPublicKey, payload) => {
+  return TransactionHeader.encode({
+    signerPublicKey,
+    batcherPublicKey,
+    familyName: FAMILY_NAME,
+    familyVersion: FAMILY_VERSION,
+    inputs: [NAMESPACE],
+    outputs: [NAMESPACE],
+    nonce: (Math.random() * 10 ** 18).toString(36),
+    payloadSha512: createHash('sha512').update(payload).digest('hex')
+  }).finish()
+}
+
+const getTxnCreator = (privateKeyHex = null, batcherPublicKeyHex = null) => {
+  const context = new secp256k1.Secp256k1Context()
+  const privateKey = privateKeyHex === null
+    ? context.newRandomPrivateKey()
+    : secp256k1.Secp256k1PrivateKey.fromHex(privateKeyHex)
+
+  const signerPublicKey = context.getPublicKey(privateKey).asHex()
+  const batcherPublicKey = batcherPublicKeyHex === null
+    ? signerPublicKey
+    : batcherPublicKeyHex
+
+  return payload => {
+    const header = encodeHeader(signerPublicKey, batcherPublicKey, payload)
+    const headerSignature = context.sign(header, privateKey)
+    return Transaction.create({ header, headerSignature, payload })
+  }
+}
+
+const submitTxns = transactions => {
+  return request({
+    method: 'POST',
+    url: `${SERVER}/api/transactions?wait`,
+    headers: { 'Content-Type': 'application/octet-stream' },
+    encoding: null,
+    body: TransactionList.encode({ transactions }).finish()
+  })
+}
+
+const encodeTimestampedPayload = message => {
+  return protos.SCPayload.encode(_.assign({
+    timestamp: Math.floor(Date.now() / 1000)
+  }, message)).finish()
+}
+
+module.exports = {
+  getTxnCreator,
+  submitTxns,
+  encodeTimestampedPayload
+}

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,0 +1,74 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM hyperledger/sawtooth-shell:1.0
+
+# Install Python, Node.js, and Ubuntu dependencies
+RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+  && apt-get update \
+  && apt-get install -y -q \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    libzmq3-dev \
+    pkg-config \
+    python3 \
+    python3-colorlog \
+    python3-dev \
+    python3-grpcio-tools=1.1.3-1 \
+    python3-grpcio=1.1.3-1 \
+    python3-nose2 \
+    python3-pip \
+    python3-protobuf \
+    python3-pytest-runner=2.6.2-1 \
+    python3-pytest=2.9.0-1 \
+    python3-sawtooth-sdk \
+    python3-sawtooth-signing \
+    python3-setuptools-scm=1.15.0-1 \
+    python3-yaml \
+    software-properties-common \
+  && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_8.x \
+  && chmod 755 /tmp/setup-node.sh \
+  && /tmp/setup-node.sh \
+  && apt-get install nodejs -y -q \
+  && rm /tmp/setup-node.sh \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g prebuild-install
+
+WORKDIR /sawtooth-supply-chain
+
+# Install NPM dependencies to central location, link to individual components
+COPY bin/splice_json bin/
+COPY asset_client/package.json asset_client/
+COPY fish_client/package.json fish_client/
+COPY server/package.json server/
+
+RUN mkdir /node_deps \
+  && bin/splice_json \
+    asset_client/package.json \
+    fish_client/package.json \
+    server/package.json \
+    > /node_deps/package.json \
+  && cd /node_deps && npm install && cd - \
+  && ln -s /node_deps/node_modules asset_client/ \
+  && ln -s /node_deps/node_modules fish_client/ \
+  && ln -s /node_deps/node_modules server/
+
+ENV PATH $PATH:/sawtooth-supply-chain/bin
+
+CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Adds a new shell container to Supply Chain which in addition to the normal `sawtooth-shell`, includes all dependencies to run all Supply Chain scripts. This shell container is then used to completely streamline deployment.

With this PR simply run `docker-compose up`, and:
- All components are started
- Protobuf classes are generated
- Static client files are generated
- The database is initialized
- `'fish'` and `'asset'` RecordTypes are added to the blockchain
- sample data for each web app are added to the blockchain

The Readme has also been updated to reflect the changes and explain the relevant docker commands.