### PR TITLE
Serve client apps from seperate Apache containers, not Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ includes a number of elements customizing the blockchain and user interaction
 with it:
 
 - a **transaction processor** which handles Supply Chain transaction logic
-- a **server** which provides an HTTP/JSON API, syncs blockchain state to a
-  local database, and serves example clients
+- a **server** which provides an HTTP/JSON API, and syncs blockchain state to a
+  local database
 - the **AssetTrack** example client for tracking generic assets
 - the **FishNet** example client for tracking fish from catch to table
 - a **shell** container with the dependencies to run any commands and scripts
@@ -42,7 +42,7 @@ with it:
 
 This project utilizes [Docker](https://www.docker.com/what-docker) to simplify
 dependencies and deployment. After cloning this repo, follow the instructions
-specific to your OS to install and run whatever components are required to run
+specific to your OS to install and run whatever components are required to use
 `docker` and `docker-compose` from your command line. This is only dependency
 required to run Supply Chain components.
 
@@ -59,11 +59,11 @@ This will take awhile the first time it runs, but when complete will be running
 all required components in separate containers. Many of the components will be
 available through HTTP endpoints, including:
 
-- The Supply Chain REST API will be at **http://localhost:8020/api**
-- AssetTrack will be at **http://localhost:8020/asset**
-- FishNet will be at **http://localhost:8020/fish**
-- RethinkDB's admin panel will be available at **http://localhost:8021**
-- Sawtooth's blockchain REST API will be available at **http://localhost:8022**
+- The Supply Chain REST API will be at **http://localhost:8020**
+- AssetTrack will be at **http://localhost:8021**
+- FishNet will be at **http://localhost:8022**
+- RethinkDB's admin panel will be available at **http://localhost:8023**
+- Sawtooth's blockchain REST API will be available at **http://localhost:8024**
 
 In bash you can shutdown these components with the key combination: `ctrl-C`.
 You can shutdown _and_ remove the containers (destroying their data), with the
@@ -150,6 +150,8 @@ The available container names include:
 - supply-shell
 - supply-processor
 - supply-server
+- supply-asset-client
+- supply-fish-client
 - supply-rethink
 - supply-validator
 - supply-settings-tp
@@ -175,8 +177,8 @@ protogen
 
 For the example clients, in addition to rebuilding them on Protobuf changes,
 any changes to their source code will require their static files be rebuilt.
-Fortunately the server does _not_ need to be restart in order to reflect
-these changes, just rebuild the static files and refresh your browser (the
+However, their containers do _not_ typically need to be restarted in order to
+reflect changes, just rebuild the static files and refresh your browser (the
 browser cache may have to be emptied):
 
 ```bash

--- a/asset_client/Dockerfile
+++ b/asset_client/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# NOTE: Use `volumes` to make: asset_client/public/
+# available at: /usr/local/apache2/htdocs/
+
+FROM httpd:2.4
+
+RUN echo "\
+\n\
+ServerName asset_client\n\
+AddDefaultCharset utf-8\n\
+LoadModule proxy_module modules/mod_proxy.so\n\
+LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+ProxyPass /api http://server:3000\n\
+ProxyPassReverse /api http://server:3000\n\
+\n\
+" >>/usr/local/apache2/conf/httpd.conf
+
+ENV PATH $PATH:/sawtooth-supply-chain/bin
+
+EXPOSE 80/tcp

--- a/asset_client/Dockerfile-installed
+++ b/asset_client/Dockerfile-installed
@@ -1,0 +1,40 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM node:8 AS static_builder
+WORKDIR /asset_client
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM httpd:2.4
+WORKDIR .
+COPY --from=static_builder /asset_client/public/ /usr/local/apache2/htdocs/
+
+RUN echo "\
+\n\
+ServerName asset_client\n\
+AddDefaultCharset utf-8\n\
+LoadModule proxy_module modules/mod_proxy.so\n\
+LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+ProxyPass /api http://server:3000\n\
+ProxyPassReverse /api http://server:3000\n\
+\n\
+" >>/usr/local/apache2/conf/httpd.conf
+
+ENV PATH $PATH:/sawtooth-supply-chain/bin
+
+EXPOSE 80/tcp

--- a/asset_client/src/services/api.js
+++ b/asset_client/src/services/api.js
@@ -20,6 +20,7 @@ const m = require('mithril')
 const _ = require('lodash')
 const sjcl = require('sjcl')
 
+const API_PATH = 'api/'
 const STORAGE_KEY = 'asset_track.authorization'
 let authToken = null
 
@@ -69,7 +70,7 @@ const baseRequest = opts => {
   const Authorization = getAuth()
   const authHeader = Authorization ? { Authorization } : {}
   opts.headers = _.assign(opts.headers, authHeader)
-  opts.url = `../api/${opts.url}`
+  opts.url = API_PATH + opts.url
   return m.request(opts)
 }
 

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -56,6 +56,32 @@ services:
         VALIDATOR_URL=tcp://validator:4004 DB_HOST=rethink node index.js
       "
 
+  asset-client:
+    image: supply-asset-client-installed
+    container_name: supply-asset-client-installed
+    build:
+      context: ./asset_client
+      dockerfile: ./Dockerfile-installed
+    expose:
+      - 80
+    ports:
+      - '8021:80'
+    depends_on:
+      - server
+
+  fish-client:
+    image: supply-fish-client-installed
+    container_name: supply-fish-client-installed
+    build:
+      context: ./fish_client
+      dockerfile: ./Dockerfile-installed
+    expose:
+      - 80
+    ports:
+      - '8022:80'
+    depends_on:
+      - server
+
   rethink:
     image: rethinkdb
     container_name: supply-rethink

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,6 +96,32 @@ services:
       - DB_HOST=rethink
     entrypoint: node index.js
 
+  asset-client:
+    image: supply-asset-client
+    container_name: supply-asset-client
+    build: ./asset_client
+    volumes:
+      - ./asset_client/public/:/usr/local/apache2/htdocs/
+    expose:
+      - 80
+    ports:
+      - '8021:80'
+    depends_on:
+      - server
+
+  fish-client:
+    image: supply-fish-client
+    container_name: supply-fish-client
+    build: ./fish_client
+    volumes:
+      - ./fish_client/public/:/usr/local/apache2/htdocs/
+    expose:
+      - 80
+    ports:
+      - '8022:80'
+    depends_on:
+      - server
+
   rethink:
     image: rethinkdb
     container_name: supply-rethink
@@ -103,7 +129,7 @@ services:
       - 8080
       - 28015
     ports:
-      - '8021:8080'
+      - '8023:8080'
       - '28020:28015'
 
   validator:
@@ -141,7 +167,7 @@ services:
     expose:
       - 8008
     ports:
-      - '8022:8008'
+      - '8024:8008'
     depends_on:
       - validator
     entrypoint: |

--- a/fish_client/Dockerfile
+++ b/fish_client/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# NOTE: Use `volumes` to make: fish_client/public/
+# available at: /usr/local/apache2/htdocs/
+
+FROM httpd:2.4
+
+RUN echo "\
+\n\
+ServerName fish_client\n\
+AddDefaultCharset utf-8\n\
+LoadModule proxy_module modules/mod_proxy.so\n\
+LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+ProxyPass /api http://server:3000\n\
+ProxyPassReverse /api http://server:3000\n\
+\n\
+" >>/usr/local/apache2/conf/httpd.conf
+
+ENV PATH $PATH:/sawtooth-supply-chain/bin
+
+EXPOSE 80/tcp

--- a/fish_client/Dockerfile-installed
+++ b/fish_client/Dockerfile-installed
@@ -1,0 +1,40 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+FROM node:8 AS static_builder
+WORKDIR /asset_client
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM httpd:2.4
+WORKDIR .
+COPY --from=static_builder /asset_client/public/ /usr/local/apache2/htdocs/
+
+RUN echo "\
+\n\
+ServerName asset_client\n\
+AddDefaultCharset utf-8\n\
+LoadModule proxy_module modules/mod_proxy.so\n\
+LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+ProxyPass /api http://server:3000\n\
+ProxyPassReverse /api http://server:3000\n\
+\n\
+" >>/usr/local/apache2/conf/httpd.conf
+
+ENV PATH $PATH:/sawtooth-supply-chain/bin
+
+EXPOSE 80/tcp

--- a/fish_client/src/services/api.js
+++ b/fish_client/src/services/api.js
@@ -20,6 +20,7 @@ const m = require('mithril')
 const _ = require('lodash')
 const sjcl = require('sjcl')
 
+const API_PATH = 'api/'
 const STORAGE_KEY = 'fish_net.authorization'
 let authToken = null
 
@@ -69,7 +70,7 @@ const baseRequest = opts => {
   const Authorization = getAuth()
   const authHeader = Authorization ? { Authorization } : {}
   opts.headers = _.assign(opts.headers, authHeader)
-  opts.url = `../api/${opts.url}`
+  opts.url = API_PATH + opts.url
   return m.request(opts)
 }
 

--- a/server/config.json.example
+++ b/server/config.json.example
@@ -9,17 +9,6 @@
 
   "DB_HOST": "localhost",
   "DB_PORT": 28015,
-  "DB_NAME": "supply_chain",
-
-  "clients": [
-    {
-      "url": "/asset",
-      "path": "../asset_client/public"
-    },
-    {
-      "url": "/fish",
-      "path": "../fish_client/public"
-    }
-  ]
+  "DB_NAME": "supply_chain"
 
 }

--- a/server/index.js
+++ b/server/index.js
@@ -32,13 +32,7 @@ Promise.all([
 ])
   .then(blockchain.subscribe)
   .then(() => {
-    config.clients.forEach(client => {
-      app.use(client.url, express.static(client.path))
-      console.log(`Added client at url "${client.url}"`)
-    })
-
-    app.use('/api', api)
-
+    app.use('/', api)
     app.listen(PORT, () => {
       console.log(`Supply Chain Server listening on port ${PORT}`)
     })

--- a/server/scripts/run_sample_updates.js
+++ b/server/scripts/run_sample_updates.js
@@ -127,7 +127,7 @@ const makeUpdateSubmitter = (count = 0) => () => {
   if (count >= LIMIT) return
   console.log(`Starting update set ${count + 1} of ${LIMIT}`)
   // Get current property values
-  return request(`${SERVER}/api/records`)
+  return request(`${SERVER}/records`)
     .then(res => {
       return JSON.parse(res).reduce((oldValues, record) => {
         return _.assign({

--- a/server/scripts/seed_sample_data.js
+++ b/server/scripts/seed_sample_data.js
@@ -83,7 +83,7 @@ protos.compile()
       user.password = agent.hashedPassword
       return request({
         method: 'POST',
-        url: `${SERVER}/api/users`,
+        url: `${SERVER}/users`,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(user)
       })

--- a/server/system/config.js
+++ b/server/system/config.js
@@ -68,22 +68,6 @@ if (!config.JWT_SECRET) {
     'Set "JWT_SECRET" as an environment variable or in "config.json" file.')
 }
 
-// Default to both asset and fish clients if none are specified
-if (!config.clients) {
-  config.clients = [
-    {
-      url: '/asset',
-      path: '../asset_client/public'
-    },
-    {
-      url: '/fish',
-      path: '../fish_client/public'
-    }
-  ]
-  console.warn('No clients specified, defaulting to AssetTrack and FishNet.')
-  console.warn('Specify static clients with the "clients" key in "config.json"')
-}
-
 // Config method to set a new value, then write it to config.json
 config.set = (key, value) => {
   config[key] = value

--- a/server/system/submit_utils.js
+++ b/server/system/submit_utils.js
@@ -35,7 +35,7 @@ const SERVER = process.env.SERVER || 'http://localhost:3000'
 const RETRY_WAIT = process.env.RETRY_WAIT || 5000
 
 const awaitServerInfo = () => {
-  return request(`${SERVER}/api/info`)
+  return request(`${SERVER}/info`)
     .catch(() => {
       console.warn(
         `Server unavailable, retrying in ${RETRY_WAIT / 1000} seconds...`)
@@ -82,7 +82,7 @@ const getTxnCreator = (privateKeyHex = null, batcherPublicKeyHex = null) => {
 const submitTxns = transactions => {
   return request({
     method: 'POST',
-    url: `${SERVER}/api/transactions?wait`,
+    url: `${SERVER}/transactions?wait`,
     headers: { 'Content-Type': 'application/octet-stream' },
     encoding: null,
     body: TransactionList.encode({ transactions }).finish()


### PR DESCRIPTION
This will help "de-monolith" the Supply Chain Server and make it easier to add or remove clients in the future.