### PR TITLE
Fix leading slash error in clients

### DIFF
--- a/asset_client/src/views/list_agents.js
+++ b/asset_client/src/views/list_agents.js
@@ -31,7 +31,7 @@ const AgentList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/agents').then((agents) => {
+      api.get('agents').then((agents) => {
         vnode.state.agents = sortBy(agents, 'name')
         vnode.state.filteredAgents = vnode.state.agents
       })

--- a/asset_client/src/views/list_assets.js
+++ b/asset_client/src/views/list_assets.js
@@ -33,7 +33,7 @@ const AssetList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/records?recordType=asset').then((records) => {
+      api.get('records?recordType=asset').then((records) => {
         vnode.state.records = records
         vnode.state.records.sort((a, b) => {
           return getLatestPropertyUpdateTime(b) - getLatestPropertyUpdateTime(a)

--- a/fish_client/src/views/list_agents.js
+++ b/fish_client/src/views/list_agents.js
@@ -31,7 +31,7 @@ const AgentList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/agents').then((agents) => {
+      api.get('agents').then((agents) => {
         vnode.state.agents = sortBy(agents, 'name')
         vnode.state.filteredAgents = vnode.state.agents
       })

--- a/fish_client/src/views/list_fish.js
+++ b/fish_client/src/views/list_fish.js
@@ -33,7 +33,7 @@ const FishList = {
     vnode.state.currentPage = 0
 
     const refresh = () => {
-      api.get('/records?recordType=fish').then((records) => {
+      api.get('records?recordType=fish').then((records) => {
         vnode.state.records = records
         vnode.state.records.sort((a, b) => {
           return getLatestPropertyUpdateTime(b) - getLatestPropertyUpdateTime(a)


### PR DESCRIPTION
The clients' `api` service expects URL paths without a leading slash, but a few pages called it with a leading slash. Must be a bug introduced in the 1.0 refactor that got missed.