### PR TITLE
Fix error caused by RethinkDB start up time

### DIFF
--- a/ledger_sync/db/index.js
+++ b/ledger_sync/db/index.js
@@ -28,6 +28,10 @@ const AWAIT_TABLE = 'blocks'
 // Connection to db for query methods, run connect before querying
 let connection = null
 
+const promisedTimeout = (fn, wait) => {
+  return new Promise(resolve => setTimeout(resolve, wait)).then(fn);
+}
+
 const awaitDatabase = () => {
   return r.tableList().run(connection)
     .then(tableNames => {
@@ -38,8 +42,7 @@ const awaitDatabase = () => {
     .catch(() => {
       console.warn('Database not initialized:', NAME)
       console.warn(`Retrying database in ${RETRY_WAIT / 1000} seconds...`)
-      return new Promise(resolve => setTimeout(resolve, RETRY_WAIT))
-        .then(awaitDatabase)
+      return promisedTimeout(awaitDatabase, RETRY_WAIT)
     })
 }
 
@@ -48,6 +51,14 @@ const connect = () => {
     .then(conn => {
       connection = conn
       return awaitDatabase()
+    })
+    .catch(err => {
+      if (err instanceof r.Error.ReqlDriverError) {
+        console.warn('Unable to connect to RethinkDB')
+        console.warn(`Retrying in ${RETRY_WAIT / 1000} seconds...`)
+        return promisedTimeout(connect, RETRY_WAIT)
+      }
+      throw err
     })
 }
 

--- a/ledger_sync/db/index.js
+++ b/ledger_sync/db/index.js
@@ -38,6 +38,7 @@ const awaitDatabase = () => {
       if (!tableNames.includes(AWAIT_TABLE)) {
         throw new Error()
       }
+      console.log('Successfully connected to database:', NAME)
     })
     .catch(() => {
       console.warn('Database not initialized:', NAME)

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -40,6 +40,7 @@ const awaitDatabase = () => {
       if (!tableNames.includes(AWAIT_TABLE)) {
         throw new Error()
       }
+      console.log('Successfully connected to database:', NAME)
     })
     .catch(() => {
       console.warn('Database not initialized:', NAME)


### PR DESCRIPTION
Makes the Ledger Sync and Server gracefully handle connection issues to RethinkDB. Previously, while they did wait for the DB to get bootstrapped, if they managed to start up before Rethink was running at all, they would crash.

Test with `docker-compose up`.

If you would like to artificially trigged the crash condition, add this to line 159 of `docker-compose.yaml`:
```yaml
    command: |
      bash -c "
        sleep 10 &&
        rethinkdb --bind all
      "
```