### PR TITLE
Add BOOLEAN data type

### DIFF
--- a/asset_client/sample_data/core_types.json
+++ b/asset_client/sample_data/core_types.json
@@ -4,28 +4,28 @@
     "properties": [
         {
           "name": "type",
-          "dataType": 1,
+          "dataType": 4,
           "required": true
         },
         {
           "name": "subtype",
-          "dataType": 1
-        },
-        {
-          "name": "weight",
-          "dataType": 2
-        },
-        {
-          "name": "location",
           "dataType": 4
         },
         {
+          "name": "weight",
+          "dataType": 3
+        },
+        {
+          "name": "location",
+          "dataType": 7
+        },
+        {
           "name": "temperature",
-          "dataType": 2
+          "dataType": 3
         },
         {
           "name": "shock",
-          "dataType": 2
+          "dataType": 3
         }
     ]
   }

--- a/asset_client/sample_data/sample_data.json
+++ b/asset_client/sample_data/sample_data.json
@@ -6,22 +6,22 @@
       "properties": [
           {
             "name": "type",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "Lightbulb"
           },
           {
             "name": "subtype",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "LED"
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 134089
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": 33928564,
               "longitude": 134615935
@@ -29,7 +29,7 @@
           },
           {
             "name": "temperature",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 44857012
           }
       ],
@@ -45,22 +45,22 @@
       "properties": [
           {
             "name": "type",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "Airliner"
           },
           {
             "name": "subtype",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "Boeing 747"
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 174540000000
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": 47499875,
               "longitude": -122208106
@@ -68,7 +68,7 @@
           },
           {
             "name": "temperature",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": -35014970
           }
       ],
@@ -81,22 +81,22 @@
       "properties": [
           {
             "name": "type",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "Coffee"
           },
           {
             "name": "subtype",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "Kona"
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 10000000
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": 19703448,
               "longitude": -155944975
@@ -104,7 +104,7 @@
           },
           {
             "name": "temperature",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 21829043
           }
       ],

--- a/asset_client/sample_data/sample_updates.json
+++ b/asset_client/sample_data/sample_updates.json
@@ -5,14 +5,14 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 1000000,
         "isRelative": true
       },
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": 542852,
           "longitude": 4127038
@@ -23,7 +23,7 @@
 
       {
         "name": "weight",
-        "dataType": 2,
+        "dataType": 3,
         "value": 10000,
         "noOpChance": 0.9,
         "isRelative": true
@@ -31,7 +31,7 @@
 
       {
         "name": "shock",
-        "dataType": 2,
+        "dataType": 3,
         "value": 50000,
         "isAlwaysPositive": true,
         "noOpChance": 0.8
@@ -45,14 +45,14 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 10000000,
         "isRelative": true
       },
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": -104551,
           "longitude": 1159712
@@ -63,7 +63,7 @@
 
       {
         "name": "weight",
-        "dataType": 2,
+        "dataType": 3,
         "value": 500000000,
         "noOpChance": 0.9,
         "isRelative": true
@@ -71,7 +71,7 @@
 
       {
         "name": "shock",
-        "dataType": 2,
+        "dataType": 3,
         "value": 500000,
         "isAlwaysPositive": true,
         "noOpChance": 0.7
@@ -85,14 +85,14 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 10000,
         "isRelative": true
       },
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": 1007305,
           "longitude": 2509187
@@ -103,7 +103,7 @@
 
       {
         "name": "weight",
-        "dataType": 2,
+        "dataType": 3,
         "value": 1000,
         "noOpChance": 0.9,
         "isRelative": true
@@ -111,7 +111,7 @@
 
       {
         "name": "shock",
-        "dataType": 2,
+        "dataType": 3,
         "value": 50000,
         "isAlwaysPositive": true,
         "noOpChance": 0.9

--- a/fish_client/sample_data/core_types.json
+++ b/fish_client/sample_data/core_types.json
@@ -4,35 +4,35 @@
     "properties": [
         {
           "name": "species",
-          "dataType": 1,
-          "required": true
-        },
-        {
-          "name": "length",
-          "dataType": 2,
-          "required": true
-        },
-        {
-          "name": "weight",
-          "dataType": 2,
-          "required": true
-        },
-        {
-          "name": "location",
           "dataType": 4,
           "required": true
         },
         {
+          "name": "length",
+          "dataType": 3,
+          "required": true
+        },
+        {
+          "name": "weight",
+          "dataType": 3,
+          "required": true
+        },
+        {
+          "name": "location",
+          "dataType": 7,
+          "required": true
+        },
+        {
           "name": "temperature",
-          "dataType": 2
+          "dataType": 3
         },
         {
           "name": "tilt",
-          "dataType": 1
+          "dataType": 4
         },
         {
           "name": "shock",
-          "dataType": 1
+          "dataType": 4
         }
     ]
   }

--- a/fish_client/sample_data/sample_data.json
+++ b/fish_client/sample_data/sample_data.json
@@ -6,22 +6,22 @@
       "properties": [
           {
             "name": "species",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "BFT"
           },
           {
             "name": "length",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 2257000
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 247096000
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": 42456486,
               "longitude": -67982434
@@ -40,22 +40,22 @@
       "properties": [
           {
             "name": "species",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "STV"
           },
           {
             "name": "length",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 672000
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 7826000
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": 46786299,
               "longitude": -92051336
@@ -71,22 +71,22 @@
       "properties": [
           {
             "name": "species",
-            "dataType": 1,
+            "dataType": 4,
             "stringValue": "SPW"
           },
           {
             "name": "length",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 20567000
           },
           {
             "name": "weight",
-            "dataType": 2,
+            "dataType": 3,
             "intValue": 57243980000
           },
           {
             "name": "location",
-            "dataType": 4,
+            "dataType": 7,
             "locationValue": {
               "latitude": -31404863,
               "longitude": 40018772

--- a/fish_client/sample_data/sample_updates.json
+++ b/fish_client/sample_data/sample_updates.json
@@ -5,7 +5,7 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 500000,
         "isRelative": true,
         "startValue": -2000000
@@ -13,7 +13,7 @@
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": -56740,
           "longitude": -99300
@@ -24,7 +24,7 @@
 
       {
         "name": "tilt",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "x": 5000000,
           "y": 5000000
@@ -34,7 +34,7 @@
 
       {
         "name": "shock",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "accel": 10000000,
           "duration": 500000
@@ -51,7 +51,7 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 1000000,
         "isRelative": true,
         "startValue": 4000000
@@ -59,7 +59,7 @@
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": -90360,
           "longitude": -61290
@@ -70,7 +70,7 @@
 
       {
         "name": "tilt",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "x": 2500000,
           "y": 2500000
@@ -80,7 +80,7 @@
 
       {
         "name": "shock",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "accel": 5000000,
           "duration": 500000
@@ -97,7 +97,7 @@
     "updates": [
       {
         "name": "temperature",
-        "dataType": 2,
+        "dataType": 3,
         "value": 3000000,
         "isRelative": true,
         "startValue": 35000000
@@ -105,7 +105,7 @@
 
       {
         "name": "location",
-        "dataType": 4,
+        "dataType": 7,
         "value": {
           "latitude": -215515,
           "longitude": -1073695
@@ -116,7 +116,7 @@
 
       {
         "name": "tilt",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "x": 10000000,
           "y": 10000000
@@ -126,7 +126,7 @@
 
       {
         "name": "shock",
-        "dataType": 1,
+        "dataType": 4,
         "value": {
           "accel": 20000000,
           "duration": 500000

--- a/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
@@ -83,8 +83,6 @@ services:
     container_name: supply-validator-test
     expose:
       - 4004
-    ports:
-      - "4004:4004"
     # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawadm keygen && \
@@ -106,8 +104,6 @@ services:
     expose:
       - 4004
       - 8008
-    ports:
-      - "8008:8008"
     depends_on:
       - validator
     entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8008 -vv

--- a/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
@@ -160,15 +160,15 @@ services:
       - 8081
     depends_on:
       - supply-server
-    command: "bash -c \" \
-        sleep 60 && \
-        nose2-3
-        -c /sawtooth-supply-chain/nose2.cfg
-        -vvv
-        -s /sawtooth-supply-chain/integration/sawtooth_integration/tests
-        test_supply_chain.TestSupplyChain --log-capture
-
-    \""
+    command: |
+      bash -c "
+        echo 'Waiting 60s to being testing . . .' &&
+        sleep 60 &&
+        nose2-3 -vvv \
+          -c /sawtooth-supply-chain/nose2.cfg \
+          -s /sawtooth-supply-chain/integration/sawtooth_integration/tests \
+          test_supply_chain.TestSupplyChain --log-capture
+      "
     stop_signal: SIGKILL
     environment:
       PYTHONPATH:

--- a/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_supply_chain_rust.yaml
@@ -20,7 +20,7 @@ services:
 
   shell:
     image: supply-shell
-    container_name: supply-shell
+    container_name: supply-shell-test
     build:
       context: ../../../
       dockerfile: shell/Dockerfile
@@ -71,7 +71,7 @@ services:
 
   settings-tp:
     image: hyperledger/sawtooth-tp_settings:latest
-    container_name: sawtooth-settings-tp-default
+    container_name: supply-settings-tp-test
     expose:
       - 4004
     depends_on:
@@ -80,7 +80,7 @@ services:
 
   validator:
     image: hyperledger/sawtooth-validator:latest
-    container_name: sawtooth-validator-default
+    container_name: supply-validator-test
     expose:
       - 4004
     ports:
@@ -102,7 +102,7 @@ services:
 
   rest-api:
     image: hyperledger/sawtooth-rest_api:latest
-    container_name: sawtooth-rest-api-default
+    container_name: supply-rest-api-test
     expose:
       - 4004
       - 8008
@@ -114,7 +114,7 @@ services:
 
   supply-server:
     image: supply-server
-    container_name: supply-server
+    container_name: supply-server-test
     build:
       context: ../../../
       dockerfile: server/Dockerfile
@@ -138,7 +138,7 @@ services:
 
   ledger-sync:
     image: supply-ledger-sync
-    container_name: supply-ledger-sync
+    container_name: supply-ledger-sync-test
     build:
       context: ../../../
       dockerfile: ledger_sync/Dockerfile

--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -270,7 +270,8 @@ class TestSupplyChain(unittest.TestCase):
             Subsequent attempts to create a type with that name will
             fail.
             ''',
-            ['species', 'weight', 'temperature', 'latitude', 'longitude'])
+            ['species', 'weight', 'temperature',
+             'latitude', 'longitude', 'is_trout'])
 
         self.assert_valid(
             jin.create_record_type(
@@ -280,6 +281,7 @@ class TestSupplyChain(unittest.TestCase):
                 ('temperature', PropertySchema.INT, False),
                 ('latitude', PropertySchema.INT, False),
                 ('longitude', PropertySchema.INT, False),
+                ('is_trout', PropertySchema.BOOLEAN, False),
             ))
 
         self.assert_invalid(
@@ -327,7 +329,7 @@ class TestSupplyChain(unittest.TestCase):
             jin.create_record(
                 'fish-456',
                 'fish',
-                {'species': 'trout', 'weight': 5}))
+                {'species': 'trout', 'weight': 5, 'is_trout': True}))
 
         self.narrate(
             '''
@@ -356,6 +358,16 @@ class TestSupplyChain(unittest.TestCase):
             jin.update_properties(
                 'fish-???',
                 {'species': 'flounder'}))
+
+        self.narrate(
+            '''
+            Jin updates is_trout.
+            ''')
+
+        self.assert_valid(
+            jin.update_properties(
+                'fish-456',
+                {'is_trout': False}))
 
         self.narrate(
             '''

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -1459,17 +1459,20 @@ impl SupplyChainTransactionHandler {
             property::PropertySchema_DataType::BYTES => {
                 reported_value.set_bytes_value(prop.get_bytes_value().to_vec())
             }
-            property::PropertySchema_DataType::STRING => {
-                reported_value.set_string_value(prop.get_string_value().to_string())
+            property::PropertySchema_DataType::BOOLEAN => {
+                reported_value.set_boolean_value(prop.get_boolean_value())
             }
             property::PropertySchema_DataType::INT => {
                 reported_value.set_int_value(prop.get_int_value())
             }
-            property::PropertySchema_DataType::FLOAT => {
-                reported_value.set_float_value(prop.get_float_value())
+            property::PropertySchema_DataType::STRING => {
+                reported_value.set_string_value(prop.get_string_value().to_string())
             }
             property::PropertySchema_DataType::LOCATION => {
                 reported_value.set_location_value(prop.get_location_value().clone())
+            }
+            property::PropertySchema_DataType::FLOAT => {
+                reported_value.set_float_value(prop.get_float_value())
             }
         };
         Ok(reported_value)

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -724,7 +724,10 @@ impl SupplyChainTransactionHandler {
 
             if provided_properties.contains_key(property_name) {
                 let provided_property = &provided_properties[property_name];
-                let reported_value = self._make_new_reported_value(0, timestamp, provided_property);
+                let reported_value = match self._make_new_reported_value(0, timestamp, provided_property) {
+                    Ok(reported_value) => reported_value,
+                    Err(err) => return Err(err),
+                };
 
                 new_property_page.reported_values.push(reported_value);
             }
@@ -904,7 +907,10 @@ impl SupplyChainTransactionHandler {
                 Err(err) => return Err(err),
             };
 
-            let reported_value = self._make_new_reported_value(reporter_index, timestamp, update);
+            let reported_value = match self._make_new_reported_value(reporter_index, timestamp, update) {
+                Ok(reported_value) => reported_value,
+                Err(err) => return Err(err),
+            };
             page.reported_values.push(reported_value);
             page.reported_values
                 .sort_by_key(|rv| (rv.clone().timestamp, rv.clone().reporter_index));
@@ -1439,12 +1445,17 @@ impl SupplyChainTransactionHandler {
         reporter_index: u32,
         timestamp: u64,
         prop: &property::PropertyValue,
-    ) -> property::PropertyPage_ReportedValue {
+    ) -> Result<property::PropertyPage_ReportedValue, ApplyError> {
         let mut reported_value = property::PropertyPage_ReportedValue::new();
         reported_value.set_reporter_index(reporter_index);
         reported_value.set_timestamp(timestamp);
 
         match prop.get_data_type() {
+            property::PropertySchema_DataType::TYPE_UNSET => {
+                return Err(ApplyError::InvalidTransaction(String::from(
+                    "DataType is not set",
+                )))
+            }
             property::PropertySchema_DataType::BYTES => {
                 reported_value.set_bytes_value(prop.get_bytes_value().to_vec())
             }
@@ -1461,7 +1472,7 @@ impl SupplyChainTransactionHandler {
                 reported_value.set_location_value(prop.get_location_value().clone())
             }
         };
-        reported_value
+        Ok(reported_value)
     }
 }
 

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -67,6 +67,7 @@ message PropertySchema {
   enum DataType {
     TYPE_UNSET = 0;
     BYTES = 1;
+    BOOLEAN = 2;
     INT = 3;
     STRING = 4;
     LOCATION = 7;
@@ -96,6 +97,7 @@ message PropertyValue {
   // one of these fields should be used, and it should match the type
   // specified for this Property in the RecordType.
   bytes bytes_value = 11;
+  bool boolean_value = 12;
   sint64 int_value = 13;
   string string_value = 14;
   Location location_value = 17;
@@ -115,6 +117,7 @@ message PropertyPage {
     // fields should be used, and it should match the type
     // specified for this Property in the RecordType.
     bytes bytes_value = 11;
+    bool boolean_value = 12;
     sint64 int_value = 13;
     string string_value = 14;
     Location location_value = 17;

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -65,11 +65,12 @@ message PropertyContainer {
 
 message PropertySchema {
   enum DataType {
-    BYTES = 0;
-    STRING = 1;
-    INT = 2;
-    FLOAT = 3;
-    LOCATION = 4;
+    TYPE_UNSET = 0;
+    BYTES = 1;
+    INT = 3;
+    STRING = 4;
+    LOCATION = 7;
+    FLOAT = 8;
   }
 
   // The name of the property, e.g. "temperature"
@@ -95,10 +96,10 @@ message PropertyValue {
   // one of these fields should be used, and it should match the type
   // specified for this Property in the RecordType.
   bytes bytes_value = 11;
-  string string_value = 12;
   sint64 int_value = 13;
-  float float_value = 14;
-  Location location_value = 15;
+  string string_value = 14;
+  Location location_value = 17;
+  float float_value = 18;
 }
 
 
@@ -114,10 +115,10 @@ message PropertyPage {
     // fields should be used, and it should match the type
     // specified for this Property in the RecordType.
     bytes bytes_value = 11;
-    string string_value = 12;
     sint64 int_value = 13;
-    float float_value = 14;
-    Location location_value = 15;
+    string string_value = 14;
+    Location location_value = 17;
+    float float_value = 18;
   }
 
   // The name of the page's associated Property and the record_id of

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -108,6 +108,7 @@ const findReportedValues =
 
 const getValue = dataType => value => {
   return r.branch(
+    r.eq(dataType, 'BOOLEAN'), value('booleanValue'),
     r.eq(dataType, 'INT'), value('intValue'),
     r.eq(dataType, 'STRING'), value('stringValue'),
     r.eq(dataType, 'FLOAT'), value('floatValue'),

--- a/tests/sawtooth_sc_test/supply_chain_message_factory.py
+++ b/tests/sawtooth_sc_test/supply_chain_message_factory.py
@@ -286,6 +286,7 @@ def _make_property_value(name, value):
     property_value = PropertyValue(name=name)
 
     type_slots = {
+        bool: 'boolean_value',
         int: 'int_value',
         str: 'string_value',
         bytes: 'bytes_value',
@@ -293,6 +294,7 @@ def _make_property_value(name, value):
     }
 
     type_tags = {
+        bool: PropertySchema.BOOLEAN,
         int: PropertySchema.INT,
         str: PropertySchema.STRING,
         bytes: PropertySchema.BYTES,


### PR DESCRIPTION
First, rearranges existing DataTypes to make room for future data type expansion, including a `TYPE_UNSET` enum for `0`, matching Sawtooth core enum usage. Then adds a simple `BOOLEAN` type.

Includes some quality-of-life updates to the integration tests, as well as adding a boolean Property to the test data.

Test by running `docker-compose up`, and/or by running the integration test:
```
bin/run_docker_test test_supply_chain_rust.yaml
```
