### PR TITLE
Add ENUM data type

### DIFF
--- a/protos/property.proto
+++ b/protos/property.proto
@@ -55,6 +55,9 @@ message Property {
   // true, the earliest page's address will be one more than the
   // current_page, or "0001" if the current_page is "ffff".
   bool wrapped = 6;
+
+  // Used with ENUM data types, the string names of available options
+  repeated string enum_options = 11;
 }
 
 
@@ -70,6 +73,7 @@ message PropertySchema {
     BOOLEAN = 2;
     INT = 3;
     STRING = 4;
+    ENUM = 5;
     LOCATION = 7;
     FLOAT = 8;
   }
@@ -83,6 +87,9 @@ message PropertySchema {
   // A flag indicating whether initial values must be provided for the
   // Property when a Record is created.
   bool required = 3;
+
+  // Used with ENUM data types, the string names of available options
+  repeated string enum_options = 11;
 }
 
 
@@ -100,6 +107,7 @@ message PropertyValue {
   bool boolean_value = 12;
   sint64 int_value = 13;
   string string_value = 14;
+  string enum_value = 15;
   Location location_value = 17;
   float float_value = 18;
 }
@@ -120,6 +128,7 @@ message PropertyPage {
     bool boolean_value = 12;
     sint64 int_value = 13;
     string string_value = 14;
+    uint32 enum_value = 15;
     Location location_value = 17;
     float float_value = 18;
   }

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -114,6 +114,7 @@ const getValue = dataType => value => {
     r.eq(dataType, 'FLOAT'), value('floatValue'),
     r.eq(dataType, 'BYTES'), value('bytesValue'),
     r.eq(dataType, 'LOCATION'), value('locationValue'),
+    r.eq(dataType, 'ENUM'), value('enumValue'),
     value('bytesValue') // if dataType is unknown, use bytesValue
   )
 }

--- a/tests/sawtooth_sc_test/supply_chain_message_factory.py
+++ b/tests/sawtooth_sc_test/supply_chain_message_factory.py
@@ -41,6 +41,12 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
 
+class Enum(object):
+    """A simple wrapper class to store an enum name with type information"""
+    def __init__(self, name):
+        self.value = name
+
+
 class SupplyChainMessageFactory:
     def __init__(self, signer=None):
         self._factory = MessageFactory(
@@ -72,8 +78,8 @@ class SupplyChainMessageFactory:
                     PropertySchema(
                         name=name,
                         data_type=data_type,
-                        required=required)
-                    for (name, data_type, required) in properties
+                        **attributes)
+                    for (name, data_type, attributes) in properties
                 ]
             )
         )
@@ -291,6 +297,7 @@ def _make_property_value(name, value):
         str: 'string_value',
         bytes: 'bytes_value',
         float: 'float_value',
+        Enum: 'enum_value',
     }
 
     type_tags = {
@@ -299,6 +306,7 @@ def _make_property_value(name, value):
         str: PropertySchema.STRING,
         bytes: PropertySchema.BYTES,
         float: PropertySchema.FLOAT,
+        Enum: PropertySchema.ENUM,
     }
 
     try:
@@ -308,7 +316,8 @@ def _make_property_value(name, value):
     except KeyError:
         raise Exception('Unsupported type')
 
-    setattr(property_value, slot, value)
+    unwrapped_value = getattr(value, 'value', value)
+    setattr(property_value, slot, unwrapped_value)
     property_value.data_type = type_tag
 
     return property_value


### PR DESCRIPTION
Adds a new `ENUM` data type. This will allow properties to be created with a limited set of valid string values, stored as integers. These valid `enum_options` are defined first in the `PropertySchema`, and later copied to the `Property`, where they are stored and referenced during updates. Later data type expansions will use this same pattern, referencing metadata stored on the `Property` to validate and complete an update.

Updates the ledger-sync to pull `enum_options` so enum values will be stored locally as their string name rather than their integer value, which matches how protobuf enums are stored.

Adds enum tests to the integration test, which can be run with:
```bash
$ bin/run_docker_test test_supply_chain_rust.yaml
```