### PR TITLE
Implement NUMBER data type, replacing INT and FLOAT

### DIFF
--- a/asset_client/sample_data/core_types.json
+++ b/asset_client/sample_data/core_types.json
@@ -13,7 +13,8 @@
         },
         {
           "name": "weight",
-          "dataType": 3
+          "dataType": 3,
+          "numberExponent": -6
         },
         {
           "name": "location",
@@ -21,11 +22,13 @@
         },
         {
           "name": "temperature",
-          "dataType": 3
+          "dataType": 3,
+          "numberExponent": -6
         },
         {
           "name": "shock",
-          "dataType": 3
+          "dataType": 3,
+          "numberExponent": -6
         }
     ]
   }

--- a/asset_client/sample_data/sample_data.json
+++ b/asset_client/sample_data/sample_data.json
@@ -17,7 +17,7 @@
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 134089
+            "numberValue": 134089
           },
           {
             "name": "location",
@@ -30,7 +30,7 @@
           {
             "name": "temperature",
             "dataType": 3,
-            "intValue": 44857012
+            "numberValue": 44857012
           }
       ],
       "ownerIndex": 0,
@@ -56,7 +56,7 @@
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 174540000000
+            "numberValue": 174540000000
           },
           {
             "name": "location",
@@ -69,7 +69,7 @@
           {
             "name": "temperature",
             "dataType": 3,
-            "intValue": -35014970
+            "numberValue": -35014970
           }
       ],
       "ownerIndex": 1
@@ -92,7 +92,7 @@
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 10000000
+            "numberValue": 10000000
           },
           {
             "name": "location",
@@ -105,7 +105,7 @@
           {
             "name": "temperature",
             "dataType": 3,
-            "intValue": 21829043
+            "numberValue": 21829043
           }
       ],
       "ownerIndex": 1

--- a/asset_client/src/services/transactions.js
+++ b/asset_client/src/services/transactions.js
@@ -31,7 +31,7 @@ const api = require('../services/api')
 
 const STORAGE_KEY = 'asset_track.encryptedKey'
 const FAMILY_NAME = 'supply_chain'
-const FAMILY_VERSION = '1.0'
+const FAMILY_VERSION = '1.1'
 const NAMESPACE = '3400de'
 
 const context = new secp256k1.Secp256k1Context()

--- a/asset_client/src/views/add_asset_form.js
+++ b/asset_client/src/views/add_asset_form.js
@@ -176,8 +176,8 @@ const _handleSubmit = (signingKey, state) => {
   if (state.weight) {
     properties.push({
       name: 'weight',
-      intValue: parsing.toInt(state.weight),
-      dataType: payloads.createRecord.enum.INT
+      numberValue: parsing.toInt(state.weight),
+      dataType: payloads.createRecord.enum.NUMBER
     })
   }
 

--- a/asset_client/src/views/asset_detail.js
+++ b/asset_client/src/views/asset_detail.js
@@ -470,8 +470,8 @@ const AssetDetail = {
               name: 'weight',
               label: 'Weight (kg)',
               record,
-              typeField: 'intValue',
-              type: payloads.updateProperties.enum.INT,
+              typeField: 'numberValue',
+              type: payloads.updateProperties.enum.NUMBER,
               xform: (x) => parsing.toInt(x),
               onsuccess: () => _loadData(vnode.attrs.recordId, vnode.state)
             })
@@ -496,8 +496,8 @@ const AssetDetail = {
               name: 'temperature',
               label: 'Temperature (°C)',
               record,
-              typeField: 'intValue',
-              type: payloads.updateProperties.enum.INT,
+              typeField: 'numberValue',
+              type: payloads.updateProperties.enum.NUMBER,
               xform: (x) => parsing.toInt(x),
               onsuccess: () => _loadData(vnode.attrs.recordId, vnode.state)
             })
@@ -513,8 +513,8 @@ const AssetDetail = {
               name: 'shock',
               label: 'Shock (g)',
               record,
-              typeField: 'intValue',
-              type: payloads.updateProperties.enum.INT,
+              typeField: 'numberValue',
+              type: payloads.updateProperties.enum.NUMBER,
               xform: (x) => parsing.toInt(x),
               onsuccess: () => _loadData(vnode.attrs.recordId, vnode.state)
             })

--- a/asset_client/src/views/property_detail.js
+++ b/asset_client/src/views/property_detail.js
@@ -40,7 +40,7 @@ const typedWidget = state => {
     })
   }
 
-  if (property.dataType === 'INT' || property.dataType === 'FLOAT') {
+  if (property.dataType === 'NUMBER') {
     return m(LineGraphWidget, { updates: property.updates })
   }
 
@@ -82,7 +82,7 @@ const updateSubmitter = state => e => {
 
 // Produces an input field particular to the type of data
 const typedInput = state => {
-  if (state.property.dataType === 'INT') {
+  if (state.property.dataType === 'NUMBER') {
     return m('.col-md-8', [
       m('input.form-control', {
         placeholder: 'Enter New Value...',

--- a/fish_client/sample_data/core_types.json
+++ b/fish_client/sample_data/core_types.json
@@ -10,12 +10,14 @@
         {
           "name": "length",
           "dataType": 3,
-          "required": true
+          "required": true,
+          "numberExponent": -6
         },
         {
           "name": "weight",
           "dataType": 3,
-          "required": true
+          "required": true,
+          "numberExponent": -6
         },
         {
           "name": "location",
@@ -24,7 +26,8 @@
         },
         {
           "name": "temperature",
-          "dataType": 3
+          "dataType": 3,
+          "numberExponent": -6
         },
         {
           "name": "tilt",

--- a/fish_client/sample_data/sample_data.json
+++ b/fish_client/sample_data/sample_data.json
@@ -12,12 +12,12 @@
           {
             "name": "length",
             "dataType": 3,
-            "intValue": 2257000
+            "numberValue": 2257000
           },
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 247096000
+            "numberValue": 247096000
           },
           {
             "name": "location",
@@ -46,12 +46,12 @@
           {
             "name": "length",
             "dataType": 3,
-            "intValue": 672000
+            "numberValue": 672000
           },
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 7826000
+            "numberValue": 7826000
           },
           {
             "name": "location",
@@ -77,12 +77,12 @@
           {
             "name": "length",
             "dataType": 3,
-            "intValue": 20567000
+            "numberValue": 20567000
           },
           {
             "name": "weight",
             "dataType": 3,
-            "intValue": 57243980000
+            "numberValue": 57243980000
           },
           {
             "name": "location",

--- a/fish_client/src/services/transactions.js
+++ b/fish_client/src/services/transactions.js
@@ -31,7 +31,7 @@ const api = require('../services/api')
 
 const STORAGE_KEY = 'fish_net.encryptedKey'
 const FAMILY_NAME = 'supply_chain'
-const FAMILY_VERSION = '1.0'
+const FAMILY_VERSION = '1.1'
 const NAMESPACE = '3400de'
 
 const context = new secp256k1.Secp256k1Context()

--- a/fish_client/src/views/add_fish_form.js
+++ b/fish_client/src/views/add_fish_form.js
@@ -195,13 +195,13 @@ const _handleSubmit = (signingKey, state) => {
       },
       {
         name: 'length',
-        intValue: parsing.toInt(state.lengthInCM),
-        dataType: payloads.createRecord.enum.INT
+        numberValue: parsing.toInt(state.lengthInCM),
+        dataType: payloads.createRecord.enum.NUMBER
       },
       {
         name: 'weight',
-        intValue: parsing.toInt(state.weightInKg),
-        dataType: payloads.createRecord.enum.INT
+        numberValue: parsing.toInt(state.weightInKg),
+        dataType: payloads.createRecord.enum.NUMBER
       },
       {
         name: 'location',

--- a/fish_client/src/views/fish_detail.js
+++ b/fish_client/src/views/fish_detail.js
@@ -577,8 +577,8 @@ const FishDetail = {
               name: 'temperature',
               label: 'Temperature (C°)',
               record,
-              typeField: 'intValue',
-              type: payloads.updateProperties.enum.INT,
+              typeField: 'numberValue',
+              type: payloads.updateProperties.enum.NUMBER,
               xform: (x) => parsing.toInt(x),
               onsuccess: () => _loadData(vnode.attrs.recordId, vnode.state)
             })

--- a/fish_client/src/views/property_detail.js
+++ b/fish_client/src/views/property_detail.js
@@ -40,7 +40,7 @@ const typedWidget = state => {
     })
   }
 
-  if (property.dataType === 'INT' || property.dataType === 'FLOAT') {
+  if (property.dataType === 'NUMBER') {
     return m(LineGraphWidget, { updates: property.updates })
   }
 

--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -278,10 +278,11 @@ class TestSupplyChain(unittest.TestCase):
             jin.create_record_type(
                 'fish',
                 ('species', PropertySchema.STRING, { 'required': True }),
-                ('weight', PropertySchema.INT, { 'required': True }),
-                ('temperature', PropertySchema.INT, {}),
-                ('latitude', PropertySchema.INT, {}),
-                ('longitude', PropertySchema.INT, {}),
+                ('weight', PropertySchema.NUMBER, { 'required': True }),
+                ('temperature', PropertySchema.NUMBER,
+                 { 'number_exponent': -3 }),
+                ('latitude', PropertySchema.NUMBER, {}),
+                ('longitude', PropertySchema.NUMBER, {}),
                 ('is_trout', PropertySchema.BOOLEAN, {}),
                 ('how_big', PropertySchema.ENUM,
                  { 'enum_options': ['big', 'bigger', 'biggest']}),
@@ -290,7 +291,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             jin.create_record_type(
                 'fish',
-                ('blarg', PropertySchema.FLOAT, { 'required': True }),
+                ('blarg', PropertySchema.NUMBER, { 'required': True }),
             ))
 
         self.narrate(
@@ -318,11 +319,11 @@ class TestSupplyChain(unittest.TestCase):
             jin.create_record(
                 'fish-456',
                 'fish',
-                {'species': 'trout', 'weight': 5.1}))
+                {'species': 'trout', 'weight': 'heavy'}))
 
         self.narrate(
             '''
-            Jin gave the value 5.1 for the property `weight`, but the
+            Jin gave the value 'heavy' for the property `weight`, but the
             type for that property is required to be int. When he
             provides a string value for `species` and an int value for
             `weight`, the record can be successfully created.
@@ -358,12 +359,12 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_valid(
             jin.update_properties(
                 'fish-456',
-                {'temperature': 4}))
+                {'temperature': -1414}))
 
         self.assert_invalid(
             jin.update_properties(
                 'fish-456',
-                {'temperature': '4'}))
+                {'temperature': '-1414'}))
 
         self.assert_invalid(
             jin.update_properties(
@@ -403,7 +404,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_valid(
             jin.update_properties(
                 'fish-456',
-                {'temperature': 3}))
+                {'temperature': -3141}))
 
         self.narrate(
             '''
@@ -416,7 +417,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             sensor_stark.update_properties(
                 'fish-456',
-                {'temperature': 3}))
+                {'temperature': -3141}))
 
         self.narrate(
             '''
@@ -454,7 +455,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             sensor_stark.update_properties(
                 'fish-456',
-                {'temperature': 3}))
+                {'temperature': -3141}))
 
         self.narrate(
             '''
@@ -486,7 +487,7 @@ class TestSupplyChain(unittest.TestCase):
             self.assert_valid(
                 sensor_stark.update_properties(
                     'fish-456',
-                    {'temperature': i}))
+                    {'temperature': -i * 1000}))
 
         self.narrate(
             '''
@@ -575,17 +576,17 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             jin.update_properties(
                 'fish-456',
-                {'temperature': 6}))
+                {'temperature': -6282}))
 
         self.assert_valid(
             sun.update_properties(
                 'fish-456',
-                {'temperature': 6}))
+                {'temperature': -6282}))
 
         self.assert_valid(
             sensor_stark.update_properties(
                 'fish-456',
-                {'temperature': 7}))
+                {'temperature': -7071}))
 
         self.narrate(
             '''
@@ -617,7 +618,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_valid(
             sensor_dollars.update_properties(
                 'fish-456',
-                {'temperature': 8}))
+                {'temperature': -8485}))
 
         self.assert_valid(
             sun.revoke_reporter(
@@ -628,7 +629,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             sensor_stark.update_properties(
                 'fish-456',
-                {'temperature': 9}))
+                {'temperature': -9899}))
 
         self.narrate(
             '''
@@ -676,7 +677,7 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_invalid(
             sun.update_properties(
                 'fish-456',
-                {'temperature': 2}))
+                {'temperature': -2828}))
 
         ##
 
@@ -763,7 +764,7 @@ class TestSupplyChain(unittest.TestCase):
         log_json(get_record_property)
 
         self.assertIn('dataType', get_record_property)
-        self.assertEqual(get_record_property['dataType'], 'INT')
+        self.assertEqual(get_record_property['dataType'], 'NUMBER')
 
         self.assertIn('name', get_record_property)
         self.assertEqual(get_record_property['name'], 'temperature')
@@ -888,7 +889,7 @@ class TestSupplyChain(unittest.TestCase):
                 ]
             ),
             {
-                'dataType': 'INT',
+                'dataType': 'NUMBER',
                 'name': 'weight',
             }
         )

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -574,7 +574,7 @@ impl SupplyChainTransactionHandler {
     pub fn new() -> SupplyChainTransactionHandler {
         SupplyChainTransactionHandler {
             family_name: "supply_chain".to_string(),
-            family_versions: vec!["1.0".to_string()],
+            family_versions: vec!["1.1".to_string()],
             namespaces: vec![get_supply_chain_prefix().to_string()],
         }
     }
@@ -715,6 +715,7 @@ impl SupplyChainTransactionHandler {
             new_property.reporters.push(reporter.clone());
             new_property.set_current_page(1);
             new_property.set_wrapped(false);
+            new_property.set_number_exponent(property.get_number_exponent());
             new_property.set_enum_options(property.enum_options);
 
             state.set_property(record_id, property_name, new_property.clone())?;
@@ -1474,8 +1475,8 @@ impl SupplyChainTransactionHandler {
             property::PropertySchema_DataType::BOOLEAN => {
                 reported_value.set_boolean_value(value.get_boolean_value())
             }
-            property::PropertySchema_DataType::INT => {
-                reported_value.set_int_value(value.get_int_value())
+            property::PropertySchema_DataType::NUMBER => {
+                reported_value.set_number_value(value.get_number_value())
             }
             property::PropertySchema_DataType::STRING => {
                 reported_value.set_string_value(value.get_string_value().to_string())
@@ -1496,9 +1497,6 @@ impl SupplyChainTransactionHandler {
             }
             property::PropertySchema_DataType::LOCATION => {
                 reported_value.set_location_value(value.get_location_value().clone())
-            }
-            property::PropertySchema_DataType::FLOAT => {
-                reported_value.set_float_value(value.get_float_value())
             }
         };
         Ok(reported_value)

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -56,6 +56,12 @@ message Property {
   // current_page, or "0001" if the current_page is "ffff".
   bool wrapped = 6;
 
+  // Used with numbers to communicate how the integer value should be converted
+  // to a fractional number. Uses the same principle as scientific notation.
+  // A number value of 1, with an exponent of 3, would be 1,000 (1 * 10^3).
+  // A number value of 1, with an exponent of -3, would be 0.001 (1 * 10^-3).
+  sint32 number_exponent = 10;
+
   // Used with ENUM data types, the string names of available options
   repeated string enum_options = 11;
 }
@@ -71,11 +77,10 @@ message PropertySchema {
     TYPE_UNSET = 0;
     BYTES = 1;
     BOOLEAN = 2;
-    INT = 3;
+    NUMBER = 3;
     STRING = 4;
     ENUM = 5;
     LOCATION = 7;
-    FLOAT = 8;
   }
 
   // The name of the property, e.g. "temperature"
@@ -87,6 +92,12 @@ message PropertySchema {
   // A flag indicating whether initial values must be provided for the
   // Property when a Record is created.
   bool required = 3;
+
+  // Used with numbers to communicate how the integer value should be converted
+  // to a fractional number. Uses the same principle as scientific notation.
+  // A number value of 1, with an exponent of 3, would be 1,000 (1 * 10^3).
+  // A number value of 1, with an exponent of -3, would be 0.001 (1 * 10^-3).
+  sint32 number_exponent = 10;
 
   // Used with ENUM data types, the string names of available options
   repeated string enum_options = 11;
@@ -105,11 +116,10 @@ message PropertyValue {
   // specified for this Property in the RecordType.
   bytes bytes_value = 11;
   bool boolean_value = 12;
-  sint64 int_value = 13;
+  sint64 number_value = 13;
   string string_value = 14;
   string enum_value = 15;
   Location location_value = 17;
-  float float_value = 18;
 }
 
 
@@ -126,11 +136,10 @@ message PropertyPage {
     // specified for this Property in the RecordType.
     bytes bytes_value = 11;
     bool boolean_value = 12;
-    sint64 int_value = 13;
+    sint64 number_value = 13;
     string string_value = 14;
     uint32 enum_value = 15;
     Location location_value = 17;
-    float float_value = 18;
   }
 
   // The name of the page's associated Property and the record_id of

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -109,9 +109,8 @@ const findReportedValues =
 const getValue = dataType => value => {
   return r.branch(
     r.eq(dataType, 'BOOLEAN'), value('booleanValue'),
-    r.eq(dataType, 'INT'), value('intValue'),
+    r.eq(dataType, 'NUMBER'), value('numberValue'),
     r.eq(dataType, 'STRING'), value('stringValue'),
-    r.eq(dataType, 'FLOAT'), value('floatValue'),
     r.eq(dataType, 'BYTES'), value('bytesValue'),
     r.eq(dataType, 'LOCATION'), value('locationValue'),
     r.eq(dataType, 'ENUM'), value('enumValue'),
@@ -143,6 +142,7 @@ const getPropertyValues = recordId => block => property => {
       return r.expr({
         'name': getName(property),
         'dataType': dataType,
+        numberExponent: property('numberExponent'),
         'reporterKeys': reporterKeys,
         'values': findReportedValues(recordId)(getName(property))(dataType)(reporterKeys)(block)
       })
@@ -215,7 +215,11 @@ const _loadRecord = (block, authedKey) => (record) => {
               )
             ),
             'reporters': getAuthorizedReporterKeys(propertyValue),
-          })),
+          }).merge(r.branch(
+            getDataType(propertyValue).eq('NUMBER'),
+            { numberExponent: propertyValue('numberExponent') },
+            {}
+          ))),
         'updates': r.expr({
           'owners': getOwners(record),
           'custodians': getCustodians(record),

--- a/server/scripts/run_sample_updates.js
+++ b/server/scripts/run_sample_updates.js
@@ -77,14 +77,11 @@ const updateValue = (update, oldValue) => {
 
 const updateProperty = (update, oldValue) => {
   oldValue = oldValue || update.startValue || null
-  const { INT, FLOAT, LOCATION } = protos.PropertySchema.DataType
+  const { NUMBER, LOCATION } = protos.PropertySchema.DataType
   const property = _.pick(update, 'name', 'dataType')
 
-  if (property.dataType === INT) {
-    property.intValue = parseInt(updateValue(update, oldValue || 0))
-
-  } else if (property.dataType === FLOAT) {
-    property.floatValue = updateValue(update, oldValue || 0)
+  if (property.dataType === NUMBER) {
+    property.numberValue = parseInt(updateValue(update, oldValue || 0))
 
   } else if (property.dataType === LOCATION) {
     const defaultLoc = { latitude: 0, longitude: 0 }

--- a/server/system/submit_utils.js
+++ b/server/system/submit_utils.js
@@ -28,7 +28,7 @@ const {
 const protos = require('../blockchain/protos')
 
 const FAMILY_NAME = 'supply_chain'
-const FAMILY_VERSION = '1.0'
+const FAMILY_VERSION = '1.1'
 const NAMESPACE = '3400de'
 
 const SERVER = process.env.SERVER || 'http://localhost:3000'

--- a/tests/sawtooth_sc_test/supply_chain_message_factory.py
+++ b/tests/sawtooth_sc_test/supply_chain_message_factory.py
@@ -51,7 +51,7 @@ class SupplyChainMessageFactory:
     def __init__(self, signer=None):
         self._factory = MessageFactory(
             family_name=addressing.FAMILY_NAME,
-            family_version='1.0',
+            family_version='1.1',
             namespace=addressing.NAMESPACE,
             signer=signer)
 
@@ -293,19 +293,17 @@ def _make_property_value(name, value):
 
     type_slots = {
         bool: 'boolean_value',
-        int: 'int_value',
+        int: 'number_value',
         str: 'string_value',
         bytes: 'bytes_value',
-        float: 'float_value',
         Enum: 'enum_value',
     }
 
     type_tags = {
         bool: PropertySchema.BOOLEAN,
-        int: PropertySchema.INT,
+        int: PropertySchema.NUMBER,
         str: PropertySchema.STRING,
         bytes: PropertySchema.BYTES,
-        float: PropertySchema.FLOAT,
         Enum: PropertySchema.ENUM,
     }
 


### PR DESCRIPTION
Although included in the original design, the FLOAT data type can introduce difficult to diagnose determinism bugs into your Transaction Processor, and it is considered best practice not to actually use it. Indeed, no Supply Chain implementation has, opting to instead use INTs with a hard-coded conversion rate (for example, millionths).

This PR formalizes that practice by removing FLOATs entirely, and giving INTs a new piece of metadata: "exponent". This refers to the exponent used in scientific notation. So for example an integer with an exponent of `-6` would be millionths of a whole unit (i.e. 10 ^ -6). Note that this does not actually affect any of the math done by the Transaction Processor, but will allow clients to properly interpret these numbers without relying on hard coded logic.

Finally, INT has been renamed NUMBER, in order to better reflect its role in storing both whole and fractional values.