### PR TITLE
Add recursive STRUCT data type

### DIFF
--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -193,7 +193,7 @@ class TestSupplyChain(unittest.TestCase):
         except AssertionError:
             raise AssertionError(
                 'Transaction is unexpectedly invalid -- {}'.format(
-                    result['data'][0]['invalid_transactions'][0]['message']))
+                    result[1]['data'][0]['invalid_transactions'][0]['message']))
 
     def assert_invalid(self, result):
         self.narrate('{}', result)

--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -272,7 +272,7 @@ class TestSupplyChain(unittest.TestCase):
             fail.
             ''',
             ['species', 'weight', 'temperature',
-             'latitude', 'longitude', 'is_trout', 'how_big'])
+             'location', 'is_trout', 'how_big'])
 
         self.assert_valid(
             jin.create_record_type(
@@ -281,8 +281,15 @@ class TestSupplyChain(unittest.TestCase):
                 ('weight', PropertySchema.NUMBER, { 'required': True }),
                 ('temperature', PropertySchema.NUMBER,
                  { 'number_exponent': -3 }),
-                ('latitude', PropertySchema.NUMBER, {}),
-                ('longitude', PropertySchema.NUMBER, {}),
+                ('location', PropertySchema.STRUCT,
+                 { 'struct_properties': [
+                    ('hemisphere', PropertySchema.STRING, {}),
+                    ('gps', PropertySchema.STRUCT,
+                     { 'struct_properties': [
+                        ('latitude', PropertySchema.NUMBER, {}),
+                        ('longitude', PropertySchema.NUMBER, {})
+                     ] })
+                 ]}),
                 ('is_trout', PropertySchema.BOOLEAN, {}),
                 ('how_big', PropertySchema.ENUM,
                  { 'enum_options': ['big', 'bigger', 'biggest']}),
@@ -341,12 +348,30 @@ class TestSupplyChain(unittest.TestCase):
             and 'biggest' are valid options for this enum.
             ''')
 
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {'species': 'trout', 'location': {
+                    'hemisphere': 'north',
+                    'gps': {'lat': 45, 'long': 45}
+                }}))
+
+        self.narrate(
+            '''
+            Jin used the keys "lat" and "long" for the gps, but the schema
+            specified "latitude" and "longitude".
+            ''')
+
         self.assert_valid(
             jin.create_record(
                 'fish-456',
                 'fish',
                 {'species': 'trout', 'weight': 5,
-                 'is_trout': True, 'how_big': Enum('bigger')}))
+                 'is_trout': True, 'how_big': Enum('bigger'),
+                 'location': {
+                    'hemisphere': 'north',
+                    'gps': {'longitude': 45, 'latitude': 45}}}))
 
         self.narrate(
             '''
@@ -405,6 +430,25 @@ class TestSupplyChain(unittest.TestCase):
             jin.update_properties(
                 'fish-456',
                 {'temperature': -3141}))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'location': {
+                    'hemisphere': 'north',
+                    'gps': {'latitude': 50, 'longitude': False}}}))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'location': {'hemisphere': 'south'}}))
+
+        self.assert_valid(
+            jin.update_properties(
+                'fish-456',
+                {'location': {
+                    'hemisphere': 'south',
+                    'gps': {'latitude': 50, 'longitude': 45}}}))
 
         self.narrate(
             '''
@@ -800,11 +844,12 @@ class TestSupplyChain(unittest.TestCase):
         self.assertEqual(get_record['owner'], sun.public_key)
         self.assertEqual(get_record['recordId'], 'fish-456')
 
-        for attr in ('latitude',
-                     'longitude',
-                     'species',
+        for attr in ('species',
                      'temperature',
-                     'weight'):
+                     'weight',
+                     'is_trout',
+                     'how_big',
+                     'location'):
             self.assertIn(attr, get_record['updates']['properties'])
 
         get_records = jin.get_records()

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -64,6 +64,9 @@ message Property {
 
   // Used with ENUM data types, the string names of available options
   repeated string enum_options = 11;
+
+  // Used with STRUCT data types, defines the properties a struct must contain
+  repeated PropertySchema struct_properties = 12;
 }
 
 
@@ -80,6 +83,7 @@ message PropertySchema {
     NUMBER = 3;
     STRING = 4;
     ENUM = 5;
+    STRUCT = 6;
     LOCATION = 7;
   }
 
@@ -101,6 +105,9 @@ message PropertySchema {
 
   // Used with ENUM data types, the string names of available options
   repeated string enum_options = 11;
+
+  // Used with STRUCT data types, defines the properties a struct must contain
+  repeated PropertySchema struct_properties = 12;
 }
 
 
@@ -119,6 +126,7 @@ message PropertyValue {
   sint64 number_value = 13;
   string string_value = 14;
   string enum_value = 15;
+  repeated PropertyValue struct_values = 16;
   Location location_value = 17;
 }
 
@@ -139,6 +147,7 @@ message PropertyPage {
     sint64 number_value = 13;
     string string_value = 14;
     uint32 enum_value = 15;
+    repeated PropertyValue struct_values = 16;
     Location location_value = 17;
   }
 

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -114,6 +114,7 @@ const getValue = dataType => value => {
     r.eq(dataType, 'BYTES'), value('bytesValue'),
     r.eq(dataType, 'LOCATION'), value('locationValue'),
     r.eq(dataType, 'ENUM'), value('enumValue'),
+    r.eq(dataType, 'STRUCT'), value('structValue'),
     value('bytesValue') // if dataType is unknown, use bytesValue
   )
 }


### PR DESCRIPTION
Structs are a recursively defined collection of other named properties, representing two or more values that are intrinsically linked, like X/Y coordinates or RGB colors. These values can be of any Supply Chain data type including STRUCT, allowing nesting to an arbitrary depth. Although versatile and powerful, Structs are somewhat heavyweight and should be used conservatively, restricted only to linking values that must always be updated together. The transaction processor will enforce this usage, rejecting any transactions that do not include a value for every property in a Struct.

To test:
```bash
bin/run_docker_test test_supply_chain_rust.yaml
```

To run components:
```bash
bin/run_docker_test test_supply_chain_rust.yaml
```