### PR TITLE
Add `/record-types` routes to the Server API

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -183,6 +183,7 @@ router.get('/records/:recordId/property/:propertyName', handle(records.fetchProp
 router.get('/records/:recordId/:propertyName', handle(records.fetchProperty))
 
 router.get('/record-types', handle(recordTypes.list))
+router.get('/record-types/:typeName', handle(recordTypes.fetch))
 
 router.post('/transactions', handleBody(blockchain.submit))
 

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -25,6 +25,7 @@ const users = require('./users')
 const { BadRequest, Unauthorized } = require('./errors')
 const agents = require('./agents')
 const records = require('./records')
+const recordTypes = require('./record_types')
 const blockchain = require('../blockchain/')
 const batcher = require('../blockchain/batcher')
 const config = require('../system/config')
@@ -180,6 +181,8 @@ router.get('/records', handle(records.listRecords))
 router.get('/records/:recordId', handle(records.fetchRecord))
 router.get('/records/:recordId/property/:propertyName', handle(records.fetchProperty))
 router.get('/records/:recordId/:propertyName', handle(records.fetchProperty))
+
+router.get('/record-types', handle(recordTypes.list))
 
 router.post('/transactions', handleBody(blockchain.submit))
 

--- a/server/api/record_types.js
+++ b/server/api/record_types.js
@@ -16,8 +16,11 @@
  */
 'use strict'
 
+const _ = require('lodash')
 const { NotFound } = require('./errors')
 const db = require('../db/record_types')
+
+const FILTER_KEYS = ['name']
 
 const fetch = ({ typeName }) => {
   return db.fetch(typeName)
@@ -29,7 +32,7 @@ const fetch = ({ typeName }) => {
     })
 }
 
-const list = () => db.list()
+const list = params => db.list(_.pick(params, FILTER_KEYS))
 
 module.exports = {
   fetch,

--- a/server/api/record_types.js
+++ b/server/api/record_types.js
@@ -16,10 +16,22 @@
  */
 'use strict'
 
+const { NotFound } = require('./errors')
 const db = require('../db/record_types')
+
+const fetch = ({ typeName }) => {
+  return db.fetch(typeName)
+    .then(resourceType => {
+      if (!resourceType) {
+        throw new NotFound(`No resource type with name: ${typeName}`)
+      }
+      return resourceType
+    })
+}
 
 const list = () => db.list()
 
 module.exports = {
+  fetch,
   list
 }

--- a/server/api/record_types.js
+++ b/server/api/record_types.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const db = require('../db/record_types')
+
+const list = () => db.list()
+
+module.exports = {
+  list
+}

--- a/server/db/record_types.js
+++ b/server/db/record_types.js
@@ -42,6 +42,15 @@ const publishRecordType = type => {
   })
 }
 
+const fetchQuery = name => currentBlock => {
+  return r.table('recordTypes')
+    .getAll(name, { index: 'name' })
+    .filter(fromBlock(currentBlock))
+    .map(publishRecordType)
+    .nth(0)
+    .default(null)
+}
+
 const listQuery = currentBlock => {
   return r.table('recordTypes')
     .filter(fromBlock(currentBlock))
@@ -49,8 +58,11 @@ const listQuery = currentBlock => {
     .coerceTo('array')
 }
 
+const fetch = name => db.queryWithCurrentBlock(fetchQuery(name))
+
 const list = () => db.queryWithCurrentBlock(listQuery)
 
 module.exports = {
+  fetch,
   list
 }

--- a/server/db/record_types.js
+++ b/server/db/record_types.js
@@ -51,16 +51,17 @@ const fetchQuery = name => currentBlock => {
     .default(null)
 }
 
-const listQuery = currentBlock => {
+const listQuery = filterQuery => currentBlock => {
   return r.table('recordTypes')
     .filter(fromBlock(currentBlock))
+    .filter(filterQuery)
     .map(publishRecordType)
     .coerceTo('array')
 }
 
 const fetch = name => db.queryWithCurrentBlock(fetchQuery(name))
 
-const list = () => db.queryWithCurrentBlock(listQuery)
+const list = filterQuery => db.queryWithCurrentBlock(listQuery(filterQuery))
 
 module.exports = {
   fetch,

--- a/server/db/record_types.js
+++ b/server/db/record_types.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2018 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const r = require('rethinkdb')
+const db = require('./')
+
+// Returns true if a resource is included in the block with the passed number
+const fromBlock = blockNum => resource => {
+  return r.and(
+    resource('startBlockNum').le(blockNum),
+    resource('endBlockNum').gt(blockNum))
+}
+
+// Transforms an array of resources with a "name" property
+// to an object where names are the keys
+const arrayToObject = namedResources => {
+  return r.object(r.args(namedResources.concatMap(resource => {
+    return [ resource('name'), resource.without('name') ]
+  })))
+}
+
+// Transforms raw recordType entity into the publishable form the API expects
+const publishRecordType = type => {
+  return r.expr({
+    name: type('name'),
+    properties: arrayToObject(type('properties'))
+  })
+}
+
+const listQuery = currentBlock => {
+  return r.table('recordTypes')
+    .filter(fromBlock(currentBlock))
+    .map(publishRecordType)
+    .coerceTo('array')
+}
+
+const list = () => db.queryWithCurrentBlock(listQuery)
+
+module.exports = {
+  list
+}


### PR DESCRIPTION
Adds new endpoints to the server's API:
- `/record-types`
- `/record-types/{type name}`
- `/record-types?name={type name}`

These fetch recordTypes from state. This was previously unnecessary as type information is hard-coded into the existing clients, but will be needed by a future universal client.

To test:
```bash
docker-compose up
```

Then in a new terminal:
```bash
curl localhost:8020/record-types
curl localhost:8020/record-types/fish
curl localhost:8020/record-types?name=fish
```