### PR TITLE
Add "delayed" field to property schemas

### DIFF
--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -280,7 +280,7 @@ class TestSupplyChain(unittest.TestCase):
                 ('species', PropertySchema.STRING, { 'required': True }),
                 ('weight', PropertySchema.NUMBER, { 'required': True }),
                 ('temperature', PropertySchema.NUMBER,
-                 { 'number_exponent': -3 }),
+                 { 'number_exponent': -3, 'delayed': True }),
                 ('location', PropertySchema.STRUCT,
                  { 'struct_properties': [
                     ('hemisphere', PropertySchema.STRING, {}),
@@ -361,6 +361,19 @@ class TestSupplyChain(unittest.TestCase):
             '''
             Jin used the keys "lat" and "long" for the gps, but the schema
             specified "latitude" and "longitude".
+            ''')
+
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {'species': 'trout', 'weight': 5,
+                 'temperature': -1000}))
+
+        self.narrate(
+            '''
+            Jin gave an initial value for temperature, but temperature is a
+            "delayed" property, and may not be set at creation time.
             ''')
 
         self.assert_valid(

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -688,6 +688,17 @@ impl SupplyChainTransactionHandler {
                     provided_name
                 )));
             };
+
+            let is_delayed = match type_schemata.get(provided_name) {
+                Some(property_schema) => property_schema.delayed,
+                None => false,
+            };
+            if is_delayed {
+                return Err(ApplyError::InvalidTransaction(format!(
+                    "Property is 'delayed', and cannot be set at record creation: {}",
+                    provided_name
+                )));
+            };
         }
         let mut new_record = record::Record::new();
         new_record.set_record_id(record_id.to_string());

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -97,6 +97,10 @@ message PropertySchema {
   // Property when a Record is created.
   bool required = 3;
 
+  // A flag that indicates a property may not be set at record creation,
+  // only later during subsequent property updates.
+  bool delayed = 5;
+
   // Used with numbers to communicate how the integer value should be converted
   // to a fractional number. Uses the same principle as scientific notation.
   // A number value of 1, with an exponent of 3, would be 1,000 (1 * 10^3).


### PR DESCRIPTION
Adds the new "delayed" field to property schemas. If set to true, it prevents a property from being given an initial value during record creation. It's easy to imagine data you wouldn't expect to be set until after record creation, but most importantly, this key will communicate context clues to a future universal client. This will allow it to omit fields from the record creation form. Currently like "shock" in the fish client are hard-coded out to be removed from the creation form.

To test:

```bash
 bin/run_docker_test test_supply_chain_rust.yaml
```