### PR TITLE
Add "fixed" field to properties

### DIFF
--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -277,7 +277,8 @@ class TestSupplyChain(unittest.TestCase):
         self.assert_valid(
             jin.create_record_type(
                 'fish',
-                ('species', PropertySchema.STRING, { 'required': True }),
+                ('species', PropertySchema.STRING,
+                 { 'required': True, 'fixed': True }),
                 ('weight', PropertySchema.NUMBER, { 'required': True }),
                 ('temperature', PropertySchema.NUMBER,
                  { 'number_exponent': -3, 'delayed': True }),
@@ -413,6 +414,16 @@ class TestSupplyChain(unittest.TestCase):
             jin.update_properties(
                 'fish-???',
                 {'species': 'flounder'}))
+
+        self.narrate(
+            '''
+            Jin attempts to update species, but it is a static property.
+            ''')
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'species': 'bass'}))
 
         self.narrate(
             '''

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -726,6 +726,7 @@ impl SupplyChainTransactionHandler {
             new_property.reporters.push(reporter.clone());
             new_property.set_current_page(1);
             new_property.set_wrapped(false);
+            new_property.set_fixed(property.get_fixed());
             new_property.set_number_exponent(property.get_number_exponent());
             new_property.set_enum_options(property.enum_options);
             new_property.set_struct_properties(property.struct_properties);
@@ -905,6 +906,13 @@ impl SupplyChainTransactionHandler {
                 return Err(ApplyError::InvalidTransaction(format!(
                     "Reporter is not authorized: {}",
                     signer
+                )));
+            }
+
+            if prop.fixed {
+                return Err(ApplyError::InvalidTransaction(format!(
+                    "Property is fixed and cannot be updated: {}",
+                    prop.name
                 )));
             }
 

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -56,6 +56,10 @@ message Property {
   // current_page, or "0001" if the current_page is "ffff".
   bool wrapped = 6;
 
+  // If set to true, values may only be set for this Property
+  // during Record creation, not later with updates.
+  bool fixed = 9;
+
   // Used with numbers to communicate how the integer value should be converted
   // to a fractional number. Uses the same principle as scientific notation.
   // A number value of 1, with an exponent of 3, would be 1,000 (1 * 10^3).
@@ -96,6 +100,10 @@ message PropertySchema {
   // A flag indicating whether initial values must be provided for the
   // Property when a Record is created.
   bool required = 3;
+
+  // Another flag. If set to true, values may only be set for this Property
+  // during Record creation, not later with updates.
+  bool fixed = 4;
 
   // A flag that indicates a property may not be set at record creation,
   // only later during subsequent property updates.

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -143,6 +143,7 @@ const getPropertyValues = recordId => block => property => {
       return r.expr({
         'name': getName(property),
         'dataType': dataType,
+        fixed: property('fixed'),
         numberExponent: property('numberExponent'),
         'reporterKeys': reporterKeys,
         'values': findReportedValues(recordId)(getName(property))(dataType)(reporterKeys)(block)
@@ -219,6 +220,10 @@ const _loadRecord = (block, authedKey) => (record) => {
           }).merge(r.branch(
             getDataType(propertyValue).eq('NUMBER'),
             { numberExponent: propertyValue('numberExponent') },
+            {}
+          )).merge(r.branch(
+            propertyValue('fixed'),
+            { fixed: propertyValue('fixed') },
             {}
           ))),
         'updates': r.expr({


### PR DESCRIPTION
The `fixed` field completes the set of boolean flags on properties, alongside `required` and `delayed`. If set to true, `fixed` designates that a property may _only_ have a value set at record creation. Any updates to property values submitted afterwards will be rejected by the transaction processor.

Besides giving more control to property schema design, this will be an important clue to a universal client. For example, with a fish record type, _species_ would be fixed. A create record form would provide a field to submit a species value, but it would _not_ allow reporters to be authorized for the field.

_Note that this field was formerly known as "static". However, as this is a reserved term in Rust, it may not be used as a property name._