### PR TITLE
Update supply_chain state for multiple addresses

### DIFF
--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -150,7 +150,7 @@ impl<'a> SupplyChainState<'a> {
 
     pub fn get_record(&mut self, record_id: &str) -> Result<Option<record::Record>, ApplyError> {
         let address = make_record_address(record_id);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let records: record::RecordContainer =
@@ -180,7 +180,7 @@ impl<'a> SupplyChainState<'a> {
         record: record::Record,
     ) -> Result<(), ApplyError> {
         let address = make_record_address(record_id);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.clone()])?;
         let mut record_container = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(records) => records,
@@ -222,8 +222,10 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -233,7 +235,7 @@ impl<'a> SupplyChainState<'a> {
         type_name: &str,
     ) -> Result<Option<record::RecordType>, ApplyError> {
         let address = make_record_type_address(type_name);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let record_types: record::RecordTypeContainer =
@@ -263,7 +265,7 @@ impl<'a> SupplyChainState<'a> {
         record_type: record::RecordType,
     ) -> Result<(), ApplyError> {
         let address = make_record_type_address(type_name);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.clone()])?;
         let mut record_types = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(record_types) => record_types,
@@ -286,15 +288,17 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
 
     pub fn get_agent(&mut self, agent_id: &str) -> Result<Option<agent::Agent>, ApplyError> {
         let address = make_agent_address(agent_id);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let agents: agent::AgentContainer =
@@ -320,7 +324,7 @@ impl<'a> SupplyChainState<'a> {
 
     pub fn set_agent(&mut self, agent_id: &str, agent: agent::Agent) -> Result<(), ApplyError> {
         let address = make_agent_address(agent_id);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.clone()])?;
         let mut agents = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(agents) => agents,
@@ -343,8 +347,10 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -355,7 +361,7 @@ impl<'a> SupplyChainState<'a> {
         property_name: &str,
     ) -> Result<Option<property::Property>, ApplyError> {
         let address = make_property_address(record_id, property_name, 0);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let properties: property::PropertyContainer =
@@ -386,7 +392,7 @@ impl<'a> SupplyChainState<'a> {
         property: property::Property,
     ) -> Result<(), ApplyError> {
         let address = make_property_address(record_id, property_name, 0);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.clone()])?;
         let mut property_container = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(properties) => properties,
@@ -426,8 +432,10 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -439,7 +447,7 @@ impl<'a> SupplyChainState<'a> {
         page: u32,
     ) -> Result<Option<property::PropertyPage>, ApplyError> {
         let address = make_property_address(record_id, property_name, page);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let property_pages: property::PropertyPageContainer =
@@ -471,7 +479,7 @@ impl<'a> SupplyChainState<'a> {
         property_page: property::PropertyPage,
     ) -> Result<(), ApplyError> {
         let address = make_property_address(record_id, property_name, page_num);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.clone()])?;
         let mut property_pages = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(property_pages) => property_pages,
@@ -511,8 +519,10 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -523,7 +533,7 @@ impl<'a> SupplyChainState<'a> {
         agent_id: &str,
     ) -> Result<Option<proposal::ProposalContainer>, ApplyError> {
         let address = make_proposal_address(record_id, agent_id);
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let proposals: proposal::ProposalContainer =
@@ -557,8 +567,10 @@ impl<'a> SupplyChainState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }


### PR DESCRIPTION
The rust sdk was updated to be able to get and set
multiple address at once. This commit updates
supply chain state object to handle this change.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>