### PR TITLE
Add unit field to Properties

### DIFF
--- a/integration/sawtooth_integration/tests/test_supply_chain.py
+++ b/integration/sawtooth_integration/tests/test_supply_chain.py
@@ -279,9 +279,10 @@ class TestSupplyChain(unittest.TestCase):
                 'fish',
                 ('species', PropertySchema.STRING,
                  { 'required': True, 'fixed': True }),
-                ('weight', PropertySchema.NUMBER, { 'required': True }),
+                ('weight', PropertySchema.NUMBER,
+                 { 'required': True, 'unit': 'grams' }),
                 ('temperature', PropertySchema.NUMBER,
-                 { 'number_exponent': -3, 'delayed': True }),
+                 { 'number_exponent': -3, 'delayed': True, 'unit': 'Celsius' }),
                 ('location', PropertySchema.STRUCT,
                  { 'struct_properties': [
                     ('hemisphere', PropertySchema.STRING, {}),

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -740,8 +740,11 @@ impl SupplyChainTransactionHandler {
             new_property.set_wrapped(false);
             new_property.set_fixed(property.get_fixed());
             new_property.set_number_exponent(property.get_number_exponent());
-            new_property.set_enum_options(property.enum_options);
-            new_property.set_struct_properties(property.struct_properties);
+            new_property.set_enum_options(
+                RepeatedField::from_vec(property.get_enum_options().to_vec()));
+            new_property.set_struct_properties(
+                RepeatedField::from_vec(property.get_struct_properties().to_vec()));
+            new_property.set_unit(property.get_unit().to_string());
 
             state.set_property(record_id, property_name, new_property.clone())?;
 

--- a/protos/property.proto
+++ b/protos/property.proto
@@ -71,6 +71,9 @@ message Property {
 
   // Used with STRUCT data types, defines the properties a struct must contain
   repeated PropertySchema struct_properties = 12;
+
+  // This optional metadata describes the unit a Property is measured in
+  string unit = 20;
 }
 
 
@@ -120,6 +123,9 @@ message PropertySchema {
 
   // Used with STRUCT data types, defines the properties a struct must contain
   repeated PropertySchema struct_properties = 12;
+
+  // This optional metadata describes the unit a Property is measured in
+  string unit = 20;
 }
 
 

--- a/server/db/records.js
+++ b/server/db/records.js
@@ -145,6 +145,7 @@ const getPropertyValues = recordId => block => property => {
         'dataType': dataType,
         fixed: property('fixed'),
         numberExponent: property('numberExponent'),
+        unit: property('unit'),
         'reporterKeys': reporterKeys,
         'values': findReportedValues(recordId)(getName(property))(dataType)(reporterKeys)(block)
       })
@@ -224,6 +225,10 @@ const _loadRecord = (block, authedKey) => (record) => {
           )).merge(r.branch(
             propertyValue('fixed'),
             { fixed: propertyValue('fixed') },
+            {}
+          )).merge(r.branch(
+            propertyValue('unit').ne(''),
+            { unit: propertyValue('unit') },
             {}
           ))),
         'updates': r.expr({


### PR DESCRIPTION
Adds `unit`, a simple metadata string which describes the unit of measure for a Property. This can be used as a clue to clients about how to display Property values.