### PR TITLE
Update build.rs files to use Customize::default()

### DIFF
--- a/processor/build.rs
+++ b/processor/build.rs
@@ -36,9 +36,7 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["src", "../protos"],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("unable to run protoc");
 
     let mut file = fs::File::create("src/messages/mod.rs").unwrap();


### PR DESCRIPTION
Protobuf updated and removed Default::default() and
instead we need to use Customize::default()

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>