### PR TITLE
Make sawtooth-supply-chain work in proxy environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,9 @@ services:
       - VALIDATOR_URL=tcp://validator:4004
       - DB_HOST=rethink
       - SERVER=http://server:3000
+      - 'http_proxy=${http_proxy}'
+      - 'https_proxy=${https_proxy}'
+      - 'no_proxy=rest-api,server,eth0,validator,${no_proxy}'
     command: |
       bash -c "
         cd asset_client/ && npm run build && cd - &&
@@ -65,6 +68,10 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+    environment:
+      - 'http_proxy=${http_proxy}'
+      - 'https_proxy=${https_proxy}'
+      - 'no_proxy=rest-api,server,eth0,validator,${no_proxy}'
     volumes:
       - .:/sawtooth-supply-chain
       - /sawtooth-supply-chain/processor/target
@@ -99,6 +106,9 @@ services:
     environment:
       - VALIDATOR_URL=tcp://validator:4004
       - DB_HOST=rethink
+      - 'http_proxy=${http_proxy}'
+      - 'https_proxy=${https_proxy}'
+      - 'no_proxy=rest-api,server,eth0,validator,${no_proxy}'
     entrypoint: node index.js
 
   ledger-sync:
@@ -120,6 +130,9 @@ services:
     environment:
       - VALIDATOR_URL=tcp://validator:4004
       - DB_HOST=rethink
+      - 'http_proxy=${http_proxy}'
+      - 'https_proxy=${https_proxy}'
+      - 'no_proxy=rest-api,server,eth0,validator,${no_proxy}'
 
   asset-client:
     image: supply-asset-client
@@ -156,6 +169,10 @@ services:
     ports:
       - '8023:8080'
       - '28020:28015'
+    environment:
+      - 'http_proxy=${http_proxy}'
+      - 'https_proxy=${https_proxy}'
+      - 'no_proxy=rest-api,server,eth0,validator,${no_proxy}'
 
   validator:
     image: hyperledger/sawtooth-validator:1.0

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -16,6 +16,30 @@ FROM rust:1
 
 RUN apt-get update && apt-get install -y unzip libzmq3-dev
 
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+  http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
+  https_proxy=$HTTPS_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+  http_proxy_host=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  http_proxy_port=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[http]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$http_proxy_host:$http_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi; \
+ if [ ! -z $https_proxy ]; then \
+  https_proxy_host=$(printf $https_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  https_proxy_port=$(printf $https_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[https]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$https_proxy_host:$https_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi;
+
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \


### PR DESCRIPTION
The docker image expects proxy environment variables be supplied,
supply-tp is unable to update crates, other images such as nodejs
too fails to connect to remote URL for npm downloads.

Similar changes may be needed for docker*installed files

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>