### PR TITLE
Bugfixes on fish and asset client

### DIFF
--- a/fish_client/src/components/forms.js
+++ b/fish_client/src/components/forms.js
@@ -109,11 +109,6 @@ const MultiSelect = {
         m(`button.btn.btn-${color}.btn-block.dropdown-toggle.text-left`,
           {
             'data-toggle': 'dropdown',
-            onclick: (e) => {
-              e.preventDefault()
-              vnode.state.show = !vnode.state.show
-            },
-            onblur: e => { vnode.state.show = false }
           }, vnode.attrs.label),
         m('.dropdown-menu.w-100', {className: vnode.state.show ? 'show' : ''},
           m("a.dropdown-item[href='#']", {

--- a/processor/src/handler.rs
+++ b/processor/src/handler.rs
@@ -1083,6 +1083,11 @@ impl SupplyChainTransactionHandler {
                     "Only the owner can create a proposal to change ownership",
                 )));
             }
+            if role == proposal::Proposal_Role::REPORTER && properties.len() == 0 {
+                return Err(ApplyError::InvalidTransaction(String::from(
+                    "Property list cannot be empty for Reporter role",
+                )))
+            }
         }
 
         if role == proposal::Proposal_Role::CUSTODIAN {


### PR DESCRIPTION
1.)Fix multi select meant to select properties while creating reporter proposal
2.)Double check that property list is not empty in a proposal for Reporter role